### PR TITLE
FIX Link to RSS feed on addons pages not working

### DIFF
--- a/mysite/code/controllers/AddonsController.php
+++ b/mysite/code/controllers/AddonsController.php
@@ -71,8 +71,12 @@ class AddonsController extends SiteController {
 		return 'Add-ons';
 	}
 
-	public function Link() {
-		return Controller::join_links(Director::baseURL(), 'add-ons');
+	public function Link($slug = null) {
+		if($slug){
+			return Controller::join_links(Director::baseURL(), 'add-ons', $slug);
+		} else {
+			return Controller::join_links(Director::baseURL(), 'add-ons');
+		}
 	}
 
 	public function ListView() {

--- a/themes/addons/templates/Layout/Addons.ss
+++ b/themes/addons/templates/Layout/Addons.ss
@@ -1,5 +1,5 @@
 <div class="page-header">
-	<h1>Modules and Themes <a class="pull-right" href="rss"><img src="themes/addons/images/feed-icon-28x28.png" width="20" alt="RSS Feed" /></a></h1>
+	<h1>Modules and Themes <a class="pull-right" href="$Link('rss')"><img src="themes/addons/images/feed-icon-28x28.png" width="20" alt="RSS Feed" /></a></h1>
 </div>
 
 <div class="add-ons">
@@ -112,4 +112,3 @@
 </div>
 
 	
-


### PR DESCRIPTION
The link was incorrectly referring to /rss when the feed is at /add-ons/rss