### PR TITLE
FIX Don't allow a single module to break the update task

### DIFF
--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -278,10 +278,15 @@ class AddonUpdater {
 		$version->CompatibleVersions()->removeAll();
 
 		foreach ($this->silverstripes as $id => $link) {
-			$constraint = $this->versionParser->parseConstraints($require);
-			if ($link->matches($constraint)) {
-				$addon->CompatibleVersions()->add($id);
-				$version->CompatibleVersions()->add($id);
+			try {
+				$constraint = $this->versionParser->parseConstraints($require);
+				if ($link->matches($constraint)) {
+					$addon->CompatibleVersions()->add($id);
+					$version->CompatibleVersions()->add($id);
+				}
+			} catch(Exception $e) {
+				// An exception here shouldn't prevent further updates.
+				Debug::log($addon->Name . "\t" . $addon->ID . "\t" . $e->getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
The issue at the moment is that when a single module provides a version constraint which is not recognised by composer, an exception is thrown which halts further updates.

In this case an older version of composer failed to validate "^3.1.0" which is now a valid constraint in newer versions.

This fix just catches the exception and logs it. I'll work on updating composer as a separate PR as there's an issue with dependencies. 