### PR TITLE
Composer file requirement update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,34 @@
 {
-	"name": "extensions.silverstripe.org",
-	"description": "The SilverStripe extensions listing site",
-	"repositories": [
+    "name": "extensions.silverstripe.org",
+    "description": "The SilverStripe extensions listing site",
+    "repositories": [
         {
             "type": "vcs",
             "url": "https://github.com/silverstripe/silverstripe-globaltoolbar.git"
         },
         {	
-        	"url": "https://github.com/chillu/silverstripe-elastica.git",
-        	"type": "vcs"
+            "url": "https://github.com/chillu/silverstripe-elastica.git",
+            "type": "vcs"
         }
     ],	
-	"require": {
-		"composer/installers": "*",
-		"ajshort/silverstripe-elastica": "dev-master#b74916afa308ca2ca878e1bdd36dfe1278c625f6",
-		"composer/composer": "*",
-		"dflydev/markdown": "1.0.*@stable",
-		"ezyang/htmlpurifier": "4.5.*@stable",
-		"guzzle/guzzle": "3.2.0",
-		"silverstripe/framework": "3.1.*@stable",
-		"silverstripe/multivaluefield": "*",
-		"silverstripe/toolbar": "^4.0",
-		"knplabs/packagist-api": "1.*@stable",
-		"stojg/silverstripe-resque": "*",
-		"ruflin/elastica": "dev-master#f235765a7b2b088fb27510a75fe3472bb94188cf",
-		"symfony/event-dispatcher": "2.7.1"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "3.7.*",
-		"silverstripe/sqlite3": "*"
-	},
-	"minimum-stability": "dev"
+    "require": {
+        "composer/installers": "*",
+        "ajshort/silverstripe-elastica": "dev-master#b74916afa308ca2ca878e1bdd36dfe1278c625f6",
+        "composer/composer": "*",
+        "michelf/php-markdown": "1.5.0",
+        "ezyang/htmlpurifier": "4.5.*@stable",
+        "guzzle/guzzle": "3.2.0",
+        "silverstripe/framework": "3.1.*@stable",
+        "silverstripe/multivaluefield": "*",
+        "silverstripe/toolbar": "^4.0",
+        "knplabs/packagist-api": "1.*@stable",
+        "stojg/silverstripe-resque": "*",
+        "ruflin/elastica": "dev-master#f235765a7b2b088fb27510a75fe3472bb94188cf",
+        "symfony/event-dispatcher": "2.7.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*",
+        "silverstripe/sqlite3": "*"
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Replaced deprecated dflydev/markdown with michelf/php-markdown in composer.json. 

I am not sure of package version so I used 1.5.0 shown on packagist. Can someone confirm my choice of version ?