### PR TITLE
API Add GitHubMarkdownService and update composer dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = tab
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # SilverStripe Addons
-This is the [SilverStripe](http://silverstripe.org) add-ons listing site
-project. It aggregates SilverStripe packages from [Packagist](http://packagist.org).
+
+This is the [SilverStripe](http://silverstripe.org) add-ons listing site project. It aggregates SilverStripe packages 
+from [Packagist](http://packagist.org).
 
 * [SilverStripe Add-ons](http://addons.silverstripe.org)
 * [GitHub Project](https://github.com/silverstripe/addons.silverstripe.org)
 * [Issue Tracker](https://github.com/silverstripe/addons.silverstripe.org/issues)
 
 ## Getting started
- 1. `git clone https://github.com/silverstripe/addons.silverstripe.org.git`
- 2. `cd` into the directory
- 3. `composer install --dev` to include any dev tools you may need during development.
- 4. Install elasticsearch `brew install elasticsearch` and configure if required
- 5. Install redis `brew install redis`
- 6. Start `elasticsearch` and `redis-server`
- 7. Start a Resque worker by running `./framework/sake dev/resque/run queue=first_build,update`
- 6. Run all tasks to populate database (see below, first run may take some time to populate)
+
+1. `git clone https://github.com/silverstripe/addons.silverstripe.org.git`
+2. `cd` into the directory
+3. `composer install`
+4. Install elasticsearch `brew install elasticsearch` and configure if required
+5. Install redis `brew install redis`
+6. Start `elasticsearch` and `redis-server`
+7. Start a Resque worker by running `./framework/sake dev/resque/run queue=first_build,update`
+8. Run all tasks to populate database (see below, first run may take some time to populate)
 
 ## Dependencies
-### Elastic Search
-[Elastic search](http://www.elasticsearch.org) is used to provide add-on package indexing and searching.
 
-The configuration is already set up in `mysite/_config/injector.yml` and will use a different index depending on whether the site is on the production server (live) or on UAT or local development environment (test or dev).
+### ElasticSearch
+
+[ElasticSearch](http://www.elasticsearch.org) is used to provide add-on package indexing and searching.
+
+The configuration is already set up in `mysite/_config/injector.yml` and will use a different index depending on 
+whether the site is on the production server (live) or on UAT or local development environment (test or dev).
 
  - Install with `brew install elasticsearch`
  - Start the server with `elasticsearch` in your terminal
@@ -28,54 +33,67 @@ The configuration is already set up in `mysite/_config/injector.yml` and will us
 You should run the elastic search reindex task to create the mappings after installation.
 
 ### Redis
-Redis is an in-memory data structure store which is used by the Resque module when processing and updating new modules from Packagist.org.
 
- - Install with `brew install redis`
- - Start the redis instance with `redis-server`
+Redis is an in-memory data structure store which is used by the Resque module when processing and updating new modules 
+from Packagist.org.
 
- Once running you can run the `UpdateAddonsTask` to pull all SilverStripe modules from Packagist into the addons site.
+* Install with `brew install redis`
+* Start the redis instance with `redis-server`
+
+Once running you can run the `UpdateAddonsTask` to pull all SilverStripe modules from Packagist into the addons site.
 
 ### Resque
-A [PHP implementation of resque](https://github.com/chrisboulton/php-resque)
-is used to provide background building of add-ons details.
-As such an installation of [redis](http://redis.io/) must be present.
-If you wish to use a remote server, you can configure the `ResqueService` constructor
-parameters to specify the backend using the injector in `mysite/_config/injector.yml`.
 
-To run the background tasks you need to spawn worker processes. On a production server
-this should be set up using a process monitor such as [god](http://godrb.com/).
-A new worker process can be spawned using the following command in the webroot:
+A [PHP implementation of resque](https://github.com/chrisboulton/php-resque) is used to provide background building 
+of add-ons details. As such an installation of [redis](http://redis.io/) must be present. If you wish to use a 
+remote server, you can configure the `ResqueService` constructor parameters to specify the backend using the 
+injector in `mysite/_config/injector.yml`.
 
-    `./framework/sake dev/resque/run queue=first_build,update`
+To run the background tasks you need to spawn worker processes. On a production server this should be set up using a 
+process monitor such as [god](http://godrb.com/). A new worker process can be spawned using the following command in 
+the webroot:
+
+```
+./framework/sake dev/resque/run queue=first_build,update
+```
 
 ## Tasks
-Run each of the following tasks in order the first time you set up the site to ensure you have a full database of modules to work with.
 
- * `framework/sake dev/tasks/UpdateSilverStripeVersionsTask`: Updates the available SilverStripe versions.
- * `framework/sake dev/tasks/UpdateAddonsTask`: Runs the add-on updater.
- * `framework/sake dev/tasks/DeleteRedundantAddonsTask`: Deletes addons which haven't been updated
+Run each of the following tasks in order the first time you set up the site to ensure you have a full database 
+of modules to work with.
+
+1. `framework/sake dev/tasks/UpdateSilverStripeVersionsTask`: Updates the available SilverStripe versions.
+2. `framework/sake dev/tasks/UpdateAddonsTask`: Runs the add-on updater.
+3. `framework/sake dev/tasks/DeleteRedundantAddonsTask`: Deletes addons which haven't been updated
    from packagist in a specified amount of time, which implies they're no longer available there.
- * `framework/sake dev/tasks/BuildAddonsTask`: Manually build addons, downloading screenshots
+4. `framework/sake dev/tasks/BuildAddonsTask`: Manually build addons, downloading screenshots
    and a README for display through the website. There's no need to set up a cron job
    for this task if you're using the resque queue.
- * `framework/sake dev/tasks/SilverStripe-Elastica-ReindexTask`: Defines and refreshes the elastic search index.
- * `framework/sake dev/tasks/CacheHelpfulRobotDataTask`: Caches Helpful Robot scores and data, so they can
+5. `framework/sake dev/tasks/SilverStripe-Elastica-ReindexTask`: Defines and refreshes the elastic search index.
+6. `framework/sake dev/tasks/CacheHelpfulRobotDataTask`: Caches Helpful Robot scores and data, so they can
    be displayed on listing and detail pages, for each addon. This also removes modules that cannot be loaded
    by requests to their repository URLs.
 
 ## Front-end build tooling
+
 The site uses [LESS](http://lesscss.org) for compiling CSS.
 
-One way to compile it is through [Grunt](http://gruntjs.org),
-which requires you to install [NodeJS](http://nodejs.org) first.
+One way to compile it is through [Grunt](http://gruntjs.org), which requires you to install 
+[NodeJS](http://nodejs.org) first.
 
-  npm install -g grunt grunt-cli
-  npm install --save-dev
+```
+npm install -g grunt grunt-cli
+npm install --save-dev
+```
 
 To compile, run:
 
-  grunt less
+```
+grunt less
+```
 
 To watch for file changes, run:
 
-  grunt watch
+```
+grunt watch
+```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "extensions.silverstripe.org",
-  "description": "The SilverStripe extensions listing site",
+  "name": "silverstripe/addons.silverstripe.org",
+  "description": "The SilverStripe addons listing site",
   "repositories": [
     {
       "type": "vcs",
@@ -8,11 +8,10 @@
     }
   ],
   "require": {
-    "composer/installers": "*",
-    "composer/composer": "*",
-    "dflydev/markdown": "1.0.*@stable",
+    "composer/installers": "^1.2",
+    "composer/composer": "^1.2",
     "ezyang/htmlpurifier": "4.5.*@stable",
-    "guzzle/guzzle": "3.2.0",
+    "guzzlehttp/guzzle": "^6.2",
     "silverstripe/framework": "3.1.*@stable",
     "silverstripe/multivaluefield": "*",
     "silverstripe/toolbar": "^4.0",
@@ -25,6 +24,9 @@
     "symfony/finder": "^2.8",
     "symfony/console": "^2.8",
     "symfony/yaml": "^2.8"
+  },
+  "replace": {
+    "extensions.silverstripe.org": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f621aaed89430a81076fdc6afd1631d9",
-    "content-hash": "4a1e90f570ed43c2f26dac2df03194f3",
+    "hash": "00b5426e9857004cba3d697aefb058e6",
+    "content-hash": "e087851005689e95411c302d86b36f06",
     "packages": [
         {
             "name": "chrisboulton/php-resque",
@@ -162,16 +162,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "5465af955800fa884a36f66ff65280584988efd0"
+                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/5465af955800fa884a36f66ff65280584988efd0",
-                "reference": "5465af955800fa884a36f66ff65280584988efd0",
+                "url": "https://api.github.com/repos/composer/composer/zipball/7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
+                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
                 "shasum": ""
             },
             "require": {
@@ -235,7 +235,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2016-11-03 16:43:15"
+            "time": "2016-12-06 21:00:51"
         },
         {
             "name": "composer/installers",
@@ -468,66 +468,6 @@
             "time": "2016-09-28 07:17:45"
         },
         {
-            "name": "dflydev/markdown",
-            "version": "v1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dflydev/dflydev-markdown.git",
-                "reference": "6baed9b50f29c980795b6656d43722aadb126f7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-markdown/zipball/6baed9b50f29c980795b6656d43722aadb126f7e",
-                "reference": "6baed9b50f29c980795b6656d43722aadb126f7e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "dflydev\\markdown": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                },
-                {
-                    "name": "Michel Fortin",
-                    "homepage": "http://michelf.com"
-                },
-                {
-                    "name": "John Gruber",
-                    "homepage": "http://daringfireball.net"
-                }
-            ],
-            "description": "PHP Markdown & Extra",
-            "homepage": "http://github.com/dflydev/dflydev-markdown",
-            "keywords": [
-                "markdown"
-            ],
-            "abandoned": "michelf/php-markdown",
-            "time": "2013-09-23 12:00:18"
-        },
-        {
             "name": "doctrine/inflector",
             "version": "v1.1.0",
             "source": {
@@ -640,22 +580,22 @@
         },
         {
             "name": "guzzle/guzzle",
-            "version": "v3.2.0",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3a3fa1c5af3ac29b5dcb216b708ee3c48b52325e"
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3a3fa1c5af3ac29b5dcb216b708ee3c48b52325e",
-                "reference": "3a3fa1c5af3ac29b5dcb216b708ee3c48b52325e",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "php": ">=5.3.2",
-                "symfony/event-dispatcher": ">=2.1"
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
             },
             "replace": {
                 "guzzle/batch": "self.version",
@@ -672,6 +612,7 @@
                 "guzzle/plugin-cache": "self.version",
                 "guzzle/plugin-cookie": "self.version",
                 "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
                 "guzzle/plugin-history": "self.version",
                 "guzzle/plugin-log": "self.version",
                 "guzzle/plugin-md5": "self.version",
@@ -681,25 +622,27 @@
                 "guzzle/stream": "self.version"
             },
             "require-dev": {
-                "doctrine/common": "*",
-                "monolog/monolog": "1.*",
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
                 "phpunit/phpunit": "3.7.*",
-                "symfony/class-loader": "*",
-                "zend/zend-cache1": "1.12",
-                "zend/zend-log1": "1.12",
-                "zendframework/zend-cache": "2.0.*",
-                "zendframework/zend-log": "2.0.*"
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.9-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Guzzle\\Tests": "tests/",
-                    "Guzzle": "src/"
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -717,7 +660,7 @@
                     "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -729,7 +672,178 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2013-02-15 01:33:10"
+            "time": "2015-03-18 18:23:50"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-10-08 15:01:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-11-18 17:47:58"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -849,6 +963,56 @@
                 "packagist"
             ],
             "time": "2015-09-07 14:25:16"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "psr/log",
@@ -1142,16 +1306,16 @@
         },
         {
             "name": "silverstripe/framework",
-            "version": "3.1.20",
+            "version": "3.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-framework.git",
-                "reference": "6f60d2518bf5265265c00935221a4b17d3c83e99"
+                "reference": "586e5281e0fac726c98d2176b63d3350932a6588"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/6f60d2518bf5265265c00935221a4b17d3c83e99",
-                "reference": "6f60d2518bf5265265c00935221a4b17d3c83e99",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/586e5281e0fac726c98d2176b63d3350932a6588",
+                "reference": "586e5281e0fac726c98d2176b63d3350932a6588",
                 "shasum": ""
             },
             "require": {
@@ -1187,7 +1351,7 @@
                 "framework",
                 "silverstripe"
             ],
-            "time": "2016-08-15 04:44:36"
+            "time": "2016-11-18 12:17:03"
         },
         {
             "name": "silverstripe/multivaluefield",
@@ -1945,16 +2109,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -1988,7 +2152,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
@@ -2117,16 +2281,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -2160,7 +2324,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2298,16 +2462,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.29",
+            "version": "4.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e"
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f19d481b468b76a7fb55eb2b772ed487e484891e",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
                 "shasum": ""
             },
             "require": {
@@ -2366,7 +2530,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-20 10:35:28"
+            "time": "2016-12-09 02:45:31"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2887,7 +3051,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "dflydev/markdown": 0,
         "ezyang/htmlpurifier": 0,
         "silverstripe/framework": 0,
         "knplabs/packagist-api": 0,

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -8,171 +8,174 @@ use Composer\Package\PackageInterface;
  */
 class AddonBuilder {
 
-	const ADDONS_DIR = 'add-ons';
+    const ADDONS_DIR = 'add-ons';
 
-	const SCREENSHOTS_DIR = 'screenshots';
+    const SCREENSHOTS_DIR = 'screenshots';
 
-	private $packagist;
+    private $packagist;
 
-	public function __construct(PackagistService $packagist) {
-		$this->packagist = $packagist;
-	}
+    public function __construct(PackagistService $packagist) {
+        $this->packagist = $packagist;
+    }
 
-	public function build(Addon $addon) {
-		$composer = $this->packagist->getComposer();
-		$downloader = $composer->getDownloadManager();
-		$packageVersions = $this->packagist->getPackageVersions($addon->Name);
-		$time = time();
+    public function build(Addon $addon) {
+        $composer = $this->packagist->getComposer();
+        $downloader = $composer->getDownloadManager();
+        $packageVersions = $this->packagist->getPackageVersions($addon->Name);
+        $time = time();
 
-		if (!$packageVersions) {
-			throw new Exception('Could not find corresponding Packagist versions');
-		}
+        if (!$packageVersions) {
+            throw new Exception('Could not find corresponding Packagist versions');
+        }
 
-		// Get the latest local and packagist version pair.
-		$version = $addon->Versions()->filter('Development', true)->first();
-		foreach ($packageVersions as $packageVersion) {
-			if ($packageVersion->getVersionNormalized() != $version->Version) {
-				continue;
-			}
+        // Get the latest local and packagist version pair.
+        $version = $addon->Versions()->filter('Development', true)->first();
+        foreach ($packageVersions as $packageVersion) {
+            if ($packageVersion->getVersionNormalized() != $version->Version) {
+                continue;
+            }
 
-			$path = implode('/', array(
-				TEMP_FOLDER, self::ADDONS_DIR, $addon->Name
-			));
+            $path = implode('/', array(
+                TEMP_FOLDER, self::ADDONS_DIR, $addon->Name
+            ));
 
-			// Convert PackagistAPI result into class compatible with Composer logic
-			$package = new Package(
-				$addon->Name,
-				$packageVersion->getVersionNormalized(),
-				$packageVersion->getVersion()
-			);
-			$package->setExtra($packageVersion->getExtra());
-			if($source = $packageVersion->getSource()) {
-				$package->setSourceUrl($source->getUrl());
-				$package->setSourceType($source->getType());
-				$package->setSourceReference($source->getReference());
-			}
-			if($dist = $packageVersion->getDist()) {
-				$package->setDistUrl($dist->getUrl());
-				$package->setDistType($dist->getType());
-				$package->setDistReference($dist->getReference());
-			}
+            // Convert PackagistAPI result into class compatible with Composer logic
+            $package = new Package(
+                $addon->Name,
+                $packageVersion->getVersionNormalized(),
+                $packageVersion->getVersion()
+            );
+            $package->setExtra($packageVersion->getExtra());
+            if($source = $packageVersion->getSource()) {
+                $package->setSourceUrl($source->getUrl());
+                $package->setSourceType($source->getType());
+                $package->setSourceReference($source->getReference());
+            }
+            if($dist = $packageVersion->getDist()) {
+                $package->setDistUrl($dist->getUrl());
+                $package->setDistType($dist->getType());
+                $package->setDistReference($dist->getReference());
+            }
 
-			$this->download($package, $path);
-			$this->buildReadme($addon, $path);
-			$this->buildScreenshots($addon, $package, $path);
-		}
+            $this->download($package, $path);
+            $this->buildReadme($addon, $path);
+            $this->buildScreenshots($addon, $package, $path);
+        }
 
-		$addon->LastBuilt = $time;
-		$addon->write();
-	}
+        $addon->LastBuilt = $time;
+        $addon->write();
+    }
 
-	protected function download(PackageInterface $package, $path) {
-		$this->packagist
-			->getComposer()
-			->getDownloadManager()
-			->download($package, $path);
-	}
+    protected function download(PackageInterface $package, $path) {
+        $this->packagist
+            ->getComposer()
+            ->getDownloadManager()
+            ->download($package, $path);
+    }
 
-	private function buildReadme(Addon $addon, $path) {
-		$candidates = array(
-			'README.md',
-			'README.markdown',
-			'README.mdown',
-			'docs/en/index.md'
-		);
+    private function buildReadme(Addon $addon, $path) {
+        $candidates = array(
+            'README.md',
+            'README.markdown',
+            'README.mdown',
+            'docs/en/index.md'
+        );
 
-		foreach ($candidates as $candidate) {
-			$lower = strtolower($candidate);
-			$paths = array("$path/$candidate", "$path/$lower");
+        foreach ($candidates as $candidate) {
+            $lower = strtolower($candidate);
+            $paths = array("$path/$candidate", "$path/$lower");
 
-			foreach ($paths as $path) {
-				if (!file_exists($path)) {
-					return;
-				}
+            foreach ($paths as $path) {
+                if (!file_exists($path)) {
+                    return;
+                }
 
-				$parser = GitHubMarkdownService::create();
-				$readme = $parser->toHtml(file_get_contents($path));
+                $parser = GitHubMarkdownService::create();
+                $readme = $parser->toHtml(file_get_contents($path));
+                if (empty($readme)) {
+                    return;
+                }
 
-				$purifier = new HTMLPurifier();
-				$readme = $purifier->purify($readme, array(
-					'Cache.SerializerPath' => TEMP_FOLDER
-				));
+                $purifier = new HTMLPurifier();
+                $readme = $purifier->purify($readme, array(
+                    'Cache.SerializerPath' => TEMP_FOLDER
+                ));
 
-				$addon->Readme = $readme;
-				return;
-			}
-		}
-	}
+                $addon->Readme = $readme;
+                return;
+            }
+        }
+    }
 
-	private function buildScreenshots(Addon $addon, PackageInterface $package, $path) {
-		$extra = $package->getExtra();
-		$screenshots = array();
-		$target = self::SCREENSHOTS_DIR . '/' . $addon->Name;
+    private function buildScreenshots(Addon $addon, PackageInterface $package, $path) {
+        $extra = $package->getExtra();
+        $screenshots = array();
+        $target = self::SCREENSHOTS_DIR . '/' . $addon->Name;
 
-		if (isset($extra['screenshots'])) {
-			$screenshots = (array) $extra['screenshots'];
-		} elseif (isset($extra['screenshot'])) {
-			$screenshots = (array) $extra['screenshot'];
-		}
+        if (isset($extra['screenshots'])) {
+            $screenshots = (array) $extra['screenshots'];
+        } elseif (isset($extra['screenshot'])) {
+            $screenshots = (array) $extra['screenshot'];
+        }
 
-		// Delete existing screenshots.
-		foreach ($addon->Screenshots() as $screenshot) {
-			$screenshot->delete();
-		}
+        // Delete existing screenshots.
+        foreach ($addon->Screenshots() as $screenshot) {
+            $screenshot->delete();
+        }
 
-		$addon->Screenshots()->removeAll();
+        $addon->Screenshots()->removeAll();
 
-		foreach ($screenshots as $screenshot) {
-			if (!is_string($screenshot)) {
-				continue;
-			}
+        foreach ($screenshots as $screenshot) {
+            if (!is_string($screenshot)) {
+                continue;
+            }
 
-			$scheme = parse_url($screenshot, PHP_URL_SCHEME);
+            $scheme = parse_url($screenshot, PHP_URL_SCHEME);
 
-			// Handle absolute image URLs.
-			if ($scheme == 'http' || $scheme == 'https') {
-				$temp = TEMP_FOLDER . '/' . md5($screenshot);
+            // Handle absolute image URLs.
+            if ($scheme == 'http' || $scheme == 'https') {
+                $temp = TEMP_FOLDER . '/' . md5($screenshot);
 
-				if (!copy($screenshot, $temp)) {
-					continue;
-				}
+                if (!copy($screenshot, $temp)) {
+                    continue;
+                }
 
-				$data = array(
-					'name' => basename($screenshot),
-					'size' => filesize($temp),
-					'tmp_name' => $temp,
-					'error' => 0
-				);
-			}
-			// Handle images that are included in the repository.
-			else {
-				$source = $path . '/' . ltrim($screenshot, '/');
+                $data = array(
+                    'name' => basename($screenshot),
+                    'size' => filesize($temp),
+                    'tmp_name' => $temp,
+                    'error' => 0
+                );
+            }
+            // Handle images that are included in the repository.
+            else {
+                $source = $path . '/' . ltrim($screenshot, '/');
 
-				// Prevent directory traversal.
-				if ($source != realpath($source)) {
-					continue;
-				}
+                // Prevent directory traversal.
+                if ($source != realpath($source)) {
+                    continue;
+                }
 
-				if (!file_exists($source)) {
-					continue;
-				}
+                if (!file_exists($source)) {
+                    continue;
+                }
 
-				$data = array(
-					'name' => basename($source),
-					'size' => filesize($source),
-					'tmp_name' => $source,
-					'error' => 0
-				);
-			}
+                $data = array(
+                    'name' => basename($source),
+                    'size' => filesize($source),
+                    'tmp_name' => $source,
+                    'error' => 0
+                );
+            }
 
-			$upload = new Upload();
-			$upload->setValidator(new AddonBuilderScreenshotValidator());
-			$upload->load($data, $target);
+            $upload = new Upload();
+            $upload->setValidator(new AddonBuilderScreenshotValidator());
+            $upload->load($data, $target);
 
-			if($file = $upload->getFile()) {
-				$addon->Screenshots()->add($file);
-			}
-		}
-	}
+            if($file = $upload->getFile()) {
+                $addon->Screenshots()->add($file);
+            }
+        }
+    }
 
 }

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -91,7 +91,9 @@ class AddonBuilder {
                 }
 
                 $parser = GitHubMarkdownService::create();
+                $parser->setContext($addon->Name);
                 $readme = $parser->toHtml(file_get_contents($path));
+
                 if (empty($readme)) {
                     return;
                 }

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -91,7 +91,9 @@ class AddonBuilder {
                 }
 
                 $parser = GitHubMarkdownService::create();
-                $parser->setContext($addon->Name);
+                if ($context = $this->getGitHubContext($addon)) {
+                    $parser->setContext($context);
+                }
                 $readme = $parser->toHtml(file_get_contents($path));
 
                 if (empty($readme)) {
@@ -107,6 +109,28 @@ class AddonBuilder {
                 return;
             }
         }
+    }
+
+    /**
+     * Determine if the repository is from GitHub, and if so then return the "context" (vendor/module) from the path
+     *
+     * @param  Addon $addon
+     * @return string|false
+     */
+    public function getGitHubContext(Addon $addon)
+    {
+        $repository = $addon->Repository;
+        if (stripos($repository, '://github.com/') === false) {
+            return false;
+        }
+
+        preg_match('/^http(?:s?):\/\/github\.com\/(?<module>.*)(\.git)?$/U', $repository, $matches);
+
+        if (isset($matches['module'])) {
+            return $matches['module'];
+        }
+
+        return false;
     }
 
     private function buildScreenshots(Addon $addon, PackageInterface $package, $path) {

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -2,7 +2,6 @@
 
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
-use dflydev\markdown\MarkdownParser;
 
 /**
  * Downloads an add-on and builds more details information about it.
@@ -42,8 +41,8 @@ class AddonBuilder {
 
 			// Convert PackagistAPI result into class compatible with Composer logic
 			$package = new Package(
-				$addon->Name, 
-				$packageVersion->getVersionNormalized(), 
+				$addon->Name,
+				$packageVersion->getVersionNormalized(),
 				$packageVersion->getVersion()
 			);
 			$package->setExtra($packageVersion->getExtra());
@@ -91,8 +90,8 @@ class AddonBuilder {
 					return;
 				}
 
-				$parser = new MarkdownParser();
-				$readme = $parser->transformMarkdown(file_get_contents($path));
+				$parser = GitHubMarkdownService::create();
+				$readme = $parser->toHtml(file_get_contents($path));
 
 				$purifier = new HTMLPurifier();
 				$readme = $purifier->purify($readme, array(

--- a/mysite/code/services/GitHubMarkdownService.php
+++ b/mysite/code/services/GitHubMarkdownService.php
@@ -19,12 +19,19 @@ class GitHubMarkdownService extends Object
     protected $client;
 
     /**
+     * The GitHub repository context
+     *
+     * @var string
+     */
+    protected $context;
+
+    /**
      * GitHub API configuration
      * @var string
      */
     const API_BASE_URI        = 'https://api.github.com';
     const API_REQUEST_METHOD  = 'POST';
-    const API_RENDER_ENDPOINT = '/markdown/raw';
+    const API_RENDER_ENDPOINT = '/markdown';
 
     /**
      * Use GitHub's API to render markdown to HTML
@@ -42,7 +49,7 @@ class GitHubMarkdownService extends Object
                     $this->getEndpoint(),
                     array(
                         'headers' => $this->getHeaders(),
-                        'body' => $markdown
+                        'body' => $this->getPayload($markdown)
                     )
                 );
         } catch (ClientException $ex) {
@@ -50,6 +57,26 @@ class GitHubMarkdownService extends Object
         }
 
         return (string) $response->getBody();
+    }
+
+    /**
+     * Get the GitHub repository context
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Set the GitHub repository context
+     * @param  string $context
+     * @return $this
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
+        return $this;
     }
 
     /**
@@ -105,6 +132,24 @@ class GitHubMarkdownService extends Object
         return array(
             'User-Agent'   => 'silverstripe/addons-site',
             'Content-Type' => 'text/x-markdown'
+        );
+    }
+
+    /**
+     * Get the payload for GFM mode parsing in the markdown API
+     *
+     * @see https://developer.github.com/v3/markdown/
+     * @param  string $markdown
+     * @return string           JSON
+     */
+    public function getPayload($markdown)
+    {
+        return Convert::raw2json(
+            array(
+                'text'    => $markdown,
+                'mode'    => 'gfm',
+                'context' => $this->getContext()
+            )
         );
     }
 }

--- a/mysite/code/services/GitHubMarkdownService.php
+++ b/mysite/code/services/GitHubMarkdownService.php
@@ -1,0 +1,110 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+
+/**
+ * A GitHub service for communicating with the GitHub API to render Markdown. Uses Guzzle as the
+ * transport method.
+ *
+ * @package mysite
+ */
+class GitHubMarkdownService extends Object
+{
+    /**
+     * The Guzzle client
+     *
+     * @var GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
+     * GitHub API configuration
+     * @var string
+     */
+    const API_BASE_URI        = 'https://api.github.com';
+    const API_REQUEST_METHOD  = 'POST';
+    const API_RENDER_ENDPOINT = '/markdown/raw';
+
+    /**
+     * Use GitHub's API to render markdown to HTML
+     *
+     * @param  string $markdown Markdown
+     * @return string           HTML
+     */
+    public function toHtml($markdown)
+    {
+        try {
+            /** @var Psr\Http\Message\ResponseInterface $response */
+            $response = $this->getClient()
+                ->request(
+                    $this->getRequestMethod(),
+                    $this->getEndpoint(),
+                    array(
+                        'headers' => $this->getHeaders(),
+                        'body' => $markdown
+                    )
+                );
+        } catch (ClientException $ex) {
+            user_error($ex->getMessage());
+        }
+
+        return (string) $response->getBody();
+    }
+
+    /**
+     * Get an instance of a GuzzleHttp client
+     * @return GuzzleHttp\Client
+     */
+    public function getClient()
+    {
+        if (is_null($this->client)) {
+            $this->client = new Client(
+                array(
+                    'base_uri' => $this->getBaseUri()
+                )
+            );
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * Get the GitHub base URI
+     * @return string
+     */
+    public function getBaseUri()
+    {
+        return self::API_BASE_URI;
+    }
+
+    /**
+     * Get the HTTP request method to use for the request
+     * @return string
+     */
+    public function getRequestMethod()
+    {
+        return self::API_REQUEST_METHOD;
+    }
+
+    /**
+     * Get the markdown parse endpoint for GitHub's API
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return self::API_RENDER_ENDPOINT;
+    }
+
+    /**
+     * Get any custom headers to use for the request
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return array(
+            'User-Agent'   => 'silverstripe/addons-site',
+            'Content-Type' => 'text/x-markdown'
+        );
+    }
+}

--- a/mysite/code/tasks/BuildAddonsTask.php
+++ b/mysite/code/tasks/BuildAddonsTask.php
@@ -43,7 +43,8 @@ class BuildAddonsTask extends BuildTask
             $addons = $addons->filter('Name', explode(',', $request->getVar('addons')));
         }
 
-        foreach($addons as $addon) { /** @var Addon $addon */
+        foreach($addons as $addon) {
+            /** @var Addon $addon */
             $this->log(sprintf('Building "%s"', $addon->Name));
             try {
                 $this->builder->build($addon);

--- a/mysite/code/tasks/BuildAddonsTask.php
+++ b/mysite/code/tasks/BuildAddonsTask.php
@@ -1,42 +1,66 @@
 <?php
 /**
- * Updates addons. Should usually be handled by a redis queue
- * which interacts directly with {@link BuildAddonJob},
- * but this task can help with debugging.
+ * Updates addons. Should usually be handled by a redis queue which interacts directly with
+ * {@link BuildAddonJob}, but this task can help with debugging.
+ *
+ * @package mysite
  */
-class BuildAddonsTask extends BuildTask {
+class BuildAddonsTask extends BuildTask
+{
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $title = 'Build Add-ons';
 
-	protected $title = 'Build Add-ons';
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $description = 'Downloads README and screenshots';
 
-	protected $description = 'Downloads README and screenshots';
+    /**
+     * @var AddonBuilder
+     */
+    protected $builder;
 
-	protected $builder;
+    /**
+     * @param AddonBuilder $builder
+     */
+    public function __construct(AddonBuilder $builder)
+    {
+        $this->builder = $builder;
+    }
 
-	function __construct(AddonBuilder $builder) {
-		$this->builder = $builder;
-	}
+    /**
+     * {@inheritDoc}
+     * @param SS_HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $addons = Addon::get();
+        if ($request->getVar('addons')) {
+            $addons = $addons->filter('Name', explode(',', $request->getVar('addons')));
+        }
 
-	public function run($request) {
-		$addons = Addon::get();
-		if($request->getVar('addons')) {
-			$addons = $addons->filter('Name', explode(',', $request->getVar('addons')));
-		}
+        foreach($addons as $addon) { /** @var Addon $addon */
+            $this->log(sprintf('Building "%s"', $addon->Name));
+            try {
+                $this->builder->build($addon);
+            } catch (RuntimeException $e) {
+                $this->log('Error: ' . $e->getMessage());
+            }
 
-		foreach($addons as $addon) {
-			$this->log(sprintf('Building "%s"', $addon->Name));
-			try {
-				$this->builder->build($addon);
-			} catch(RuntimeException $e) {
-				$this->log('Error: ' . $e->getMessage());
-			}
-			
-			$addon->BuildQueued = false;
-			$addon->write();
-		}
-	}
+            $addon->BuildQueued = false;
+            $addon->write();
+        }
+    }
 
-	protected function log($msg) {
-		echo $msg . "\n";
-	}
-
+    /**
+     * @param string $msg
+     */
+    protected function log($msg)
+    {
+        echo $msg . PHP_EOL;
+    }
 }

--- a/mysite/code/tasks/CacheHelpfulRobotDataTask.php
+++ b/mysite/code/tasks/CacheHelpfulRobotDataTask.php
@@ -1,18 +1,25 @@
 <?php
-
+/**
+ * Class for communicating with helpful robot
+ *
+ * @package mysite
+ */
 class CacheHelpfulRobotDataTask extends BuildTask
 {
     /**
+     * {@inheritDoc]
      * @var string
      */
     protected $title = 'Cache Helpful Robot Data';
 
     /**
+     * {@inheritDoc}
      * @var string
      */
     protected $description = 'Downloads and stores Helpful Robot module data';
 
     /**
+     * {@inheritDoc}
      * @param SS_HTTPRequest $request
      */
     public function run($request)
@@ -65,7 +72,7 @@ class CacheHelpfulRobotDataTask extends BuildTask
         if (Director::is_cli()) {
             print $message . PHP_EOL;
         } else {
-            print $message . "<br>";
+            print $message . '<br>';
         }
     }
 }

--- a/mysite/code/tasks/DeleteRedundantAddonsTask.php
+++ b/mysite/code/tasks/DeleteRedundantAddonsTask.php
@@ -31,13 +31,15 @@ class DeleteRedundantAddonsTask extends BuildTask
 
         $addons = Addon::get()->filter('LastUpdated:LessThan', $dateOneWeekAgo);
 
-        foreach ($addons as $addon) { /** @var Addon $addon */
+        foreach ($addons as $addon) {
+            /** @var Addon $addon */
             try {
                 $addon->Keywords()->removeAll();
                 $addon->Screenshots()->removeAll();
                 $addon->CompatibleVersions()->removeAll();
 
-                foreach ($addon->Versions() as $version) { /** @var AddonVersion $version */
+                foreach ($addon->Versions() as $version) {
+                    /** @var AddonVersion $version */
                     $version->Authors()->removeAll();
                     $version->Keywords()->removeAll();
                     $version->CompatibleVersions()->removeAll();

--- a/mysite/code/tasks/DeleteRedundantAddonsTask.php
+++ b/mysite/code/tasks/DeleteRedundantAddonsTask.php
@@ -1,37 +1,53 @@
 <?php
+
+use Elastica\Exception\NotFoundException;
+
 /**
  * Deletes packages removed from Packagist.
+ *
+ * @package mysite
  */
-class DeleteRedundantAddonsTask extends BuildTask {
+class DeleteRedundantAddonsTask extends BuildTask
+{
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $title = 'Delete Redundant Add-ons';
 
-	protected $title = 'Delete Redundant Add-ons ';
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $description = 'Deletes packages removed from Packagist';
 
-	protected $description = 'Deletes packages removed from Packagist';
+    /**
+     * {@inheritDoc}
+     * @param SS_HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $dateOneWeekAgo  = date('Y-m-d', strtotime('-1 week'));
 
-	public function run($request) {
-		$dateOneWeekAgo  = date('Y-m-d', strtotime('-1 week'));
+        $addons = Addon::get()->filter('LastUpdated:LessThan', $dateOneWeekAgo);
 
-		$addons = Addon::get()->filter('LastUpdated:LessThan' , $dateOneWeekAgo);
+        foreach ($addons as $addon) { /** @var Addon $addon */
+            try {
+                $addon->Keywords()->removeAll();
+                $addon->Screenshots()->removeAll();
+                $addon->CompatibleVersions()->removeAll();
 
-		foreach ($addons as $addon) {
-			try {
-				$addon->Keywords()->removeAll();
-				$addon->Screenshots()->removeAll();
-				$addon->CompatibleVersions()->removeAll();
+                foreach ($addon->Versions() as $version) { /** @var AddonVersion $version */
+                    $version->Authors()->removeAll();
+                    $version->Keywords()->removeAll();
+                    $version->CompatibleVersions()->removeAll();
+                    $version->delete();
+                }
 
-				foreach ($addon->Versions() as $version) {
-					$version->Authors()->removeAll();
-					$version->Keywords()->removeAll();
-					$version->CompatibleVersions()->removeAll();
-					$version->delete();
-				}
-
-				$addon->delete();
-			} catch(Elastica\Exception\NotFoundException $e) {
-				// no-op
-			}
-			
-		}
-	}
-
+                $addon->delete();
+            } catch (NotFoundException $e) {
+                // no-op
+            }
+        }
+    }
 }

--- a/mysite/code/tasks/UpdateAddonsTask.php
+++ b/mysite/code/tasks/UpdateAddonsTask.php
@@ -1,24 +1,45 @@
 <?php
 /**
  * Runs the add-on updater.
+ *
+ * @package mysite
  */
-class UpdateAddonsTask extends BuildTask {
+class UpdateAddonsTask extends BuildTask
+{
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $title = 'Update Add-ons';
 
-	protected $title = 'Update Add-ons';
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $description = 'Updates add-ons from Packagist';
 
-	protected $description = 'Updates add-ons from Packagist';
+    /**
+     * @var AddonUpdater
+     */
+    private $updater;
 
-	private $updater;
+    /**
+     * @param AddonUpdater $updater
+     */
+    public function __construct(AddonUpdater $updater)
+    {
+        $this->updater = $updater;
+    }
 
-	public function __construct(AddonUpdater $updater) {
-		$this->updater = $updater;
-	}
-
-	public function run($request) {
-		$this->updater->update(
-			(bool)$request->getVar('clear'),
-			$request->getVar('addons') ? explode(',', $request->getVar('addons')) : null
-		);
-	}
-
+    /**
+     * {@inheritDoc}
+     * @param SS_HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $this->updater->update(
+            (bool)$request->getVar('clear'),
+            $request->getVar('addons') ? explode(',', $request->getVar('addons')) : null
+        );
+    }
 }

--- a/mysite/code/tasks/UpdateSilverStripeVersionsTask.php
+++ b/mysite/code/tasks/UpdateSilverStripeVersionsTask.php
@@ -1,24 +1,42 @@
 <?php
 /**
  * Updates the available SilverStripe versions.
+ *
+ * @package mysite
  */
-class UpdateSilverStripeVersionsTask extends BuildTask {
+class UpdateSilverStripeVersionsTask extends BuildTask
+{
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $title = 'Update SilverStripe Versions';
 
-	protected $title = 'Update SilverStripe Versions';
+    /**
+     * {@inheritDoc}
+     * @var string
+     */
+    protected $description = 'Updates the available SilverStripe versions';
 
-	protected $description = 'Updates the available SilverStripe versions';
+    /**
+     * @var SilverStripeVersionUpdater
+     */
+    private $updater;
 
-	/**
-	 * @var SilverStripeVersionUpdater
-	 */
-	private $updater;
+    /**
+     * @param SilverStripeVersionUpdater $updater
+     */
+    public function __construct(SilverStripeVersionUpdater $updater)
+    {
+        $this->updater = $updater;
+    }
 
-	public function __construct(SilverStripeVersionUpdater $updater) {
-		$this->updater = $updater;
-	}
-
-	public function run($request) {
-		$this->updater->update();
-	}
-
+    /**
+     * {@inheritDoc}
+     * @param SS_HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $this->updater->update();
+    }
 }

--- a/mysite/tests/services/AddonBuilderTest.php
+++ b/mysite/tests/services/AddonBuilderTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Tests for the AddonBuilder
+ */
+class AddonBuilderTest extends SapphireTest
+{
+    /**
+     * Test that a GitHub repository can be identified, and have its context returned if it matches
+     *
+     * @param string $input
+     * @param string|false $expected
+     * @dataProvider repositoryContextProvider
+     */
+    public function testGetGitHubContext($input, $expected)
+    {
+        $addon = new Addon(array('Repository' => $input));
+        $builder = new AddonBuilder(new PackagistService);
+        $result = $builder->getGitHubContext($addon);
+        $this->assertSame($expected, $result);
+    }
+
+    public function repositoryContextProvider()
+    {
+        return array(
+            array('https://github.com/silverstripe/addons.org.git', 'silverstripe/addons.org'),
+            array('http://github.com/silverstripe/addons.org.git', 'silverstripe/addons.org'),
+            array('https://github.com/silverstripe/sspak.git', 'silverstripe/sspak'),
+            array('http://github.com/silverstripe/sspak.git', 'silverstripe/sspak')
+        );
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+    <testsuite name="Default">
+        <directory>mysite/tests</directory>
+    </testsuite>
+
+    <listeners>
+        <listener class="SS_TestListener" file="framework/dev/TestListener.php" />
+    </listeners>
+
+    <groups>
+        <exclude>
+            <group>sanitychecks</group>
+        </exclude>
+    </groups>
+</phpunit>


### PR DESCRIPTION
* Replace dflydev/markdown with GitHub markdown parsing via API
* Tidy up readme formatting
* Fix some composer validation failures in composer.json
* Change editor config to be closer to PSR-2, add doc blocks to BuildTasks

This resolves #141, resolves #61, resolves #90 and resolves #115.

# To-do

- [x] Use GitHub API to render markdown instead of erusev/parsedown
- [x] Update guzzlehttp/guzzle for general use
- [x] Ensure legacy guzzle/guzzle still works with Packagist API
- [x] Test update/build addon tasks and frontend