### PR TITLE
FIX Remove abandoned packages during the "update" process

### DIFF
--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -82,7 +82,9 @@ class AddonUpdater {
 		}
 		$this->elastica->startBulkIndex();
 
-		foreach ($packages as $package) { /** @var Packagist\Api\Result\Package $package */
+		foreach ($packages as $package) {
+			/** @var Packagist\Api\Result\Package $package */
+
 			$isAbandoned = (property_exists($package, 'abandoned') && $package->abandoned);
 			$name = $package->getName();
 			$versions = $package->getVersions();


### PR DESCRIPTION
During the update process we will delete `Addon` instances in the system that Packagist has identified as "abandoned". When the build task runs it won't encounter them again since they're gone.

Resolves #138

For reference - running locally identifies 48 abandoned packages.