### PR TITLE
Display popular modules on averaged downloads per day

### DIFF
--- a/mysite/_config/routes.yml
+++ b/mysite/_config/routes.yml
@@ -9,3 +9,4 @@ Director:
     "authors": AuthorsController
     "tags": TagsController
     "submit": SubmitAddonController
+    "addonSort": AjaxController

--- a/mysite/code/controllers/AjaxController.php
+++ b/mysite/code/controllers/AjaxController.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class AjaxController
+ * handle the ajax call to select the sorting and return a json response
+ */
+class AjaxController extends Controller
+{
+
+    private static $allowed_actions = array(
+        'index'
+    );
+
+    /**
+     * @param SS_HTTPRequest $request
+     * @return SS_HTTPResponse
+     */
+    public function index(SS_HTTPRequest $request)
+    {
+        $sortMethod = $request->postVar('type') . 'PopularAddons';
+        $addons = HomeController::$sortMethod(5);
+        $body = $this->renderWith('PopularAddons', array('PopularAddons' => $addons));
+        $response = new SS_HTTPResponse();
+        $response->addHeader('Content-Type', 'application/json');
+        $response->setBody(Convert::array2json(array('success' => true, 'body' => $body->getValue())));
+        return $response;
+    }
+
+}

--- a/mysite/code/controllers/HomeController.php
+++ b/mysite/code/controllers/HomeController.php
@@ -1,86 +1,124 @@
 <?php
+
 /**
  * The home page controller.
  */
-class HomeController extends SiteController {
+class HomeController extends SiteController
+{
 
-	private static $popular_blacklist = array(
-		'silverstripe/framework',
-		'silverstripe/cms',
-		'silverstripe/sqlite3',
-		'silverstripe/postgresql',
-		'silverstripe-themes/simple'
-	);
+    private static $popular_blacklist = array(
+        'silverstripe/framework',
+        'silverstripe/cms',
+        'silverstripe/sqlite3',
+        'silverstripe/postgresql',
+        'silverstripe-themes/simple'
+    );
 
-	public static $allowed_actions = array(
-		'index'
-	);
+    public static $allowed_actions = array(
+        'index'
+    );
 
-	public function index() {
-		return $this->renderWith(array('Home', 'Page'));
-	}
+    public function index()
+    {
+        return $this->renderWith(array('Home', 'Page'));
+    }
 
-	public function Title() {
-		return 'Home';
-	}
+    public function Title()
+    {
+        return 'Home';
+    }
 
-	public function Link() {
-		return Director::baseURL();
-	}
+    public function Link()
+    {
+        return Director::baseURL();
+    }
 
-	public function PopularAddons($limit = 10) {
-		return Addon::get()
-			->sort('Downloads', 'DESC')
-			->exclude('Name', $this->config()->popular_blacklist)
-			->limit($limit);
-	}
+    /**
+     * @param int $limit
+     * @return DataList|SS_Limitable default to Relative addons
+     */
+    public function PopularAddons($limit = 10)
+    {
+        return self::RelativePopularAddons($limit);
+    }
 
-	public function NewestAddons($limit = 10) {
-		return Addon::get()->sort('Released', 'DESC')->limit($limit);
-	}
+    /**
+     * @param int $limit
+     * @return DataList|SS_Limitable List sorted by absolute downloads
+     */
+    public static function AbsolutePopularAddons($limit = 10)
+    {
+        return Addon::get()
+            ->sort('Downloads', 'DESC')
+            ->exclude('Name', self::config()->popular_blacklist)
+            ->limit($limit);
+    }
 
-	public function RandomAddons($limit = 10) {
-		return Addon::get()->sort(DB::getConn()->random(), 'DESC')->limit($limit);
-	}
+    public static function RelativePopularAddons($limit = 10)
+    {
+        $addons = Addon::get()
+            ->exclude(array('Name' => self::config()->popular_blacklist));
+        $list = ArrayList::create($addons->toArray());
+        /** @var ArrayList $addons */
+        $addons = $list->sort('relativePopularity DESC');
+        $addons = $addons->limit($limit);
+        foreach ($addons as $addon) {
+            $addon->Score = $addon->relativePopularityFormatted() . ' per day';
+        }
 
-	public function NewestVersions($limit = 10) {
-		return AddonVersion::get()
-			->filter('Development', false)
-			->sort('Released', 'DESC')
-			->limit($limit);
-	}
+        return $addons;
+    }
 
-	public function ChartData() {
-		$chartData = array();
-		$list = ArrayList::create(array());
+    public function NewestAddons($limit = 10)
+    {
+        return Addon::get()->sort('Released', 'DESC')->limit($limit);
+    }
 
-		$sqlQuery = new SQLQuery();
-		$sqlQuery->setFrom('Addon');
-		$sqlQuery->setSelect('DATE(Created) as Created');
-		$sqlQuery->selectField('COUNT(*)', 'CountInOneDay');
-		$sqlQuery->addWhere('"Created" >= DATE_SUB(NOW(), INTERVAL 30 DAY)');
-		$sqlQuery->addGroupBy('DATE(Created)');
+    public function RandomAddons($limit = 10)
+    {
+        return Addon::get()->sort(DB::getConn()->random(), 'DESC')->limit($limit);
+    }
 
-		$result = $sqlQuery->execute();
+    public function NewestVersions($limit = 10)
+    {
+        return AddonVersion::get()
+            ->filter('Development', false)
+            ->sort('Released', 'DESC')
+            ->limit($limit);
+    }
 
-		if(count($result)) {
-			foreach($result as $row) {
-				$date = date('j M Y', strtotime($row['Created']));
-				if(!isset($chartData[$date])) {
-					$chartData[$date] = $row['CountInOneDay'];
-				}
-			}
-		}
+    public function ChartData()
+    {
+        $chartData = array();
+        $list = ArrayList::create(array());
 
-		if(count($chartData)) {
-			foreach($chartData as $x => $y) {
-				$list->push(ArrayData::create(array(
-					'XValue' => $x,
-					'YValue' => $y
-				)));
-			}
-		}
+        $sqlQuery = new SQLQuery();
+        $sqlQuery->setFrom('Addon');
+        $sqlQuery->setSelect('DATE(Created) as Created');
+        $sqlQuery->selectField('COUNT(*)', 'CountInOneDay');
+        $sqlQuery->addWhere('"Created" >= DATE_SUB(NOW(), INTERVAL 30 DAY)');
+        $sqlQuery->addGroupBy('DATE(Created)');
 
-		return $list;
-	}
+        $result = $sqlQuery->execute();
+
+        if (count($result)) {
+            foreach ($result as $row) {
+                $date = date('j M Y', strtotime($row['Created']));
+                if (!isset($chartData[$date])) {
+                    $chartData[$date] = $row['CountInOneDay'];
+                }
+            }
+        }
+
+        if (count($chartData)) {
+            foreach ($chartData as $x => $y) {
+                $list->push(ArrayData::create(array(
+                    'XValue' => $x,
+                    'YValue' => $y
+                )));
+            }
+        }
+
+        return $list;
+    }
 }

--- a/mysite/code/dataobjects/Addon.php
+++ b/mysite/code/dataobjects/Addon.php
@@ -6,169 +6,216 @@ use Elastica\Type\Mapping;
 /**
  * An add-on with one or more versions.
  */
-class Addon extends DataObject {
+class Addon extends DataObject
+{
 
-	public static $db = array(
-		'Name' => 'Varchar(255)',
-		'Description' => 'Text',
-		'Type' => 'Varchar(100)',
-		'Readme' => 'HTMLText',
-		'Released' => 'SS_Datetime',
-		'Repository' => 'Varchar(255)',
-		'Downloads' => 'Int',
-		'DownloadsMonthly' => 'Int',
-		'Favers' => 'Int',
-		'LastUpdated' => 'SS_Datetime',
-		'LastBuilt' => 'SS_Datetime',
-		'BuildQueued' => 'Boolean',
-		'HelpfulRobotData' => 'Text',
-		'HelpfulRobotScore' => 'Int',
-	);
+    public static $db = array(
+        'Name'              => 'Varchar(255)',
+        'Description'       => 'Text',
+        'Type'              => 'Varchar(100)',
+        'Readme'            => 'HTMLText',
+        'Released'          => 'SS_Datetime',
+        'Repository'        => 'Varchar(255)',
+        'Downloads'         => 'Int',
+        'DownloadsMonthly'  => 'Int',
+        'Favers'            => 'Int',
+        'LastUpdated'       => 'SS_Datetime',
+        'LastBuilt'         => 'SS_Datetime',
+        'BuildQueued'       => 'Boolean',
+        'HelpfulRobotData'  => 'Text',
+        'HelpfulRobotScore' => 'Int',
+    );
 
-	public static $has_one = array(
-		'Vendor' => 'AddonVendor'
-	);
+    public static $has_one = array(
+        'Vendor' => 'AddonVendor'
+    );
 
-	public static $has_many = array(
-		'Versions' => 'AddonVersion'
-	);
+    public static $has_many = array(
+        'Versions' => 'AddonVersion'
+    );
 
-	public static $many_many = array(
-		'Keywords' => 'AddonKeyword',
-		'Screenshots' => 'Image',
-		'CompatibleVersions' => 'SilverStripeVersion'
-	);
+    public static $many_many = array(
+        'Keywords'           => 'AddonKeyword',
+        'Screenshots'        => 'Image',
+        'CompatibleVersions' => 'SilverStripeVersion'
+    );
 
-	public static $default_sort = 'Name';
+    public static $default_sort = 'Name';
 
-	public static $extensions = array(
-		'SilverStripe\\Elastica\\Searchable'
-	);
+    public static $extensions = array(
+        'SilverStripe\\Elastica\\Searchable'
+    );
 
-	/**
-	 * Gets the addon's versions sorted from newest to oldest.
-	 *
-	 * @return ArrayList
-	 */
-	public function SortedVersions() {
-		$versions = $this->Versions()->toArray();
+    /**
+     * Gets the addon's versions sorted from newest to oldest.
+     *
+     * @return ArrayList
+     */
+    public function SortedVersions()
+    {
+        $versions = $this->Versions()->toArray();
 
-		usort($versions, function($a, $b) {
-			return version_compare($b->Version, $a->Version);
-		});
+        usort($versions, function ($a, $b) {
+            return version_compare($b->Version, $a->Version);
+        });
 
-		return new ArrayList($versions);
-	}
+        return new ArrayList($versions);
+    }
 
-	public function MasterVersion() {
-		return $this->Versions()->filter('PrettyVersion', array('dev-master', 'trunk'))->First();
-	}
+    public function MasterVersion()
+    {
+        return $this->Versions()->filter('PrettyVersion', array('dev-master', 'trunk'))->First();
+    }
 
-	public function Authors() {
-		return $this->Versions()->relation('Authors');
-	}
+    public function Authors()
+    {
+        return $this->Versions()->relation('Authors');
+    }
 
-	public function VendorName() {
-		return substr($this->Name, 0, strpos($this->Name, '/'));
-	}
+    public function VendorName()
+    {
+        return substr($this->Name, 0, strpos($this->Name, '/'));
+    }
 
-	public function VendorLink() {
-		return Controller::join_links(
-			Director::baseURL(), 'add-ons', $this->VendorName()
-		);
-	}
+    public function VendorLink()
+    {
+        return Controller::join_links(
+            Director::baseURL(), 'add-ons', $this->VendorName()
+        );
+    }
 
-	public function PackageName() {
-		return substr($this->Name, strpos($this->Name, '/') + 1);
-	}
+    public function PackageName()
+    {
+        return substr($this->Name, strpos($this->Name, '/') + 1);
+    }
 
-	public function Link() {
-		return Controller::join_links(
-			Director::baseURL(), 'add-ons', $this->Name
-		);
-	}
+    public function Link()
+    {
+        return Controller::join_links(
+            Director::baseURL(), 'add-ons', $this->Name
+        );
+    }
 
-	public function DescriptionText() {
-		return $this->Description;
-	}
+    public function DescriptionText()
+    {
+        return $this->Description;
+    }
 
-	public function RSSTitle() {
-		return sprintf('New module release: %s', $this->Name);
-	}
+    public function RSSTitle()
+    {
+        return sprintf('New module release: %s', $this->Name);
+    }
 
-	public function PackagistUrl()
-	{
-		return "https://packagist.org/packages/$this->Name";
-	}
+    public function PackagistUrl()
+    {
+        return "https://packagist.org/packages/$this->Name";
+    }
 
-	/**
-	 * Remove the effect of code of conduct Helpful Robot measure that we currently don't include in the Supported module definition
-	 *
-	 * @return integer Adjusted Helpful Robot score
-	 */
-	public function getAdjustedHelpfulRobotScore()
-	{
-		return round(min(100, $this->HelpfulRobotScore / 92.9 * 100));
-	}
+    /**
+     * Remove the effect of code of conduct Helpful Robot measure that we currently don't include in the Supported module definition
+     *
+     * @return integer Adjusted Helpful Robot score
+     */
+    public function getAdjustedHelpfulRobotScore()
+    {
+        return round(min(100, $this->HelpfulRobotScore / 92.9 * 100));
+    }
 
-	public function getElasticaMapping() {
-		return new Mapping(null, array(
-			'name' => array('type' => 'string'),
-			'description' => array('type' => 'string'),
-			'type' => array('type' => 'string'),
-			'compatibility' => array('type' => 'string'),
-			'vendor' => array('type' => 'string'),
-			'tags' => array('type' => 'string'),
-			'released' => array('type' => 'date'),
-			'downloads' => array('type' => 'string'),
-			'readme' => array('type' => 'string')
-		));
-	}
+    public function getElasticaMapping()
+    {
+        return new Mapping(null, array(
+            'name'          => array('type' => 'string'),
+            'description'   => array('type' => 'string'),
+            'type'          => array('type' => 'string'),
+            'compatibility' => array('type' => 'string'),
+            'vendor'        => array('type' => 'string'),
+            'tags'          => array('type' => 'string'),
+            'released'      => array('type' => 'date'),
+            'downloads'     => array('type' => 'string'),
+            'readme'        => array('type' => 'string')
+        ));
+    }
 
-	public function getElasticaDocument() {
-		return new Document($this->ID, array(
-			'name' => $this->Name,
-			'description' => $this->Description,
-			'type' => $this->Type,
-			'compatibility' => $this->CompatibleVersions()->column('Name'),
-			'vendor' => $this->VendorName(),
-			'tags' => $this->Keywords()->column('Name'),
-			'released' => $this->obj('Released')->Format('c'),
-			'downloads' => (int) $this->Downloads,
-			'readme' => strip_tags($this->Readme),
-			'_boost' => sqrt($this->Downloads)
-		));
-	}
+    public function getElasticaDocument()
+    {
+        return new Document($this->ID, array(
+            'name'          => $this->Name,
+            'description'   => $this->Description,
+            'type'          => $this->Type,
+            'compatibility' => $this->CompatibleVersions()->column('Name'),
+            'vendor'        => $this->VendorName(),
+            'tags'          => $this->Keywords()->column('Name'),
+            'released'      => $this->obj('Released')->Format('c'),
+            'downloads'     => (int)$this->Downloads,
+            'readme'        => strip_tags($this->Readme),
+            '_boost'        => sqrt($this->Downloads)
+        ));
+    }
 
-	public function onBeforeDelete() {
-		parent::onBeforeDelete();
+    public function onBeforeDelete()
+    {
+        parent::onBeforeDelete();
 
-		// Partially cascade delete. Leave author and keywords in place,
-		// since they might be related to other addons.
-		foreach($this->Screenshots() as $image) {
-			$image->delete();
-		}
-		$this->Screenshots()->removeAll();
+        // Partially cascade delete. Leave author and keywords in place,
+        // since they might be related to other addons.
+        foreach ($this->Screenshots() as $image) {
+            $image->delete();
+        }
+        $this->Screenshots()->removeAll();
 
-		foreach($this->Versions() as $version) {
-			$version->delete();
-		}
+        foreach ($this->Versions() as $version) {
+            $version->delete();
+        }
 
-		$this->Keywords()->removeAll();
-		$this->CompatibleVersions()->removeAll();
-	}
+        $this->Keywords()->removeAll();
+        $this->CompatibleVersions()->removeAll();
+    }
 
-	public function getDateCreated() {
-		return date('Y-m-d', strtotime($this->Created));
-	}
+    public function getDateCreated()
+    {
+        return date('Y-m-d', strtotime($this->Created));
+    }
 
-	/**
-	 * @return array
-	 */
-	public function HelpfulRobotData()
-	{
-		$data = json_decode($this->HelpfulRobotData, true);
+    /**
+     * @return ArrayData
+     */
+    public function HelpfulRobotData()
+    {
+        $data = json_decode($this->HelpfulRobotData, true);
 
-		return new ArrayData($data["inspections"][0]);
-	}
+        return new ArrayData($data["inspections"][0]);
+    }
+
+    /**
+     *
+     * @return bool|DateInterval
+     */
+    public function addonAge()
+    {
+        $date = new DateTime();
+        $released = new DateTime($this->Released);
+
+        return $date->diff($released);
+    }
+
+    /**
+     * Calculate the total amount of downloads per day
+     * Based on the total amount of downloads divided by the age of the addon
+     *
+     * @return float
+     */
+    public function getRelativePopularity()
+    {
+        return (int)$this->Downloads / (int)$this->addonAge()->days;
+    }
+
+    /**
+     * Format the relative popularity to a nicely readable number
+     *
+     * @return string
+     */
+    public function relativePopularityFormatted()
+    {
+        return number_format($this->getRelativePopularity(), 2);
+    }
 }

--- a/themes/addons/css/addons.css
+++ b/themes/addons/css/addons.css
@@ -6312,3 +6312,7 @@ body {
 #home-search {
   margin-top: 16px;
 }
+#popularsort {
+  float: right;
+  margin-top: 5px;
+}

--- a/themes/addons/javascript/addons.js
+++ b/themes/addons/javascript/addons.js
@@ -6,4 +6,15 @@ jQuery(function($) {
 	
 	// Bootstrap tooltips
 	$('[data-toggle=tooltip]').tooltip();
+
+	$('#popularsort').on('change', function() {
+		var selection = $(this).val();
+		$.post('/addonSort', {'type': selection}, function(result) {
+			if(result.success) {
+				$('#popularAddons').html(result.body);
+				// We need to re-bind the tooltips
+                $('[data-toggle=tooltip]').tooltip();
+            }
+		}, 'JSON')
+	});
 });

--- a/themes/addons/less/pages/home.less
+++ b/themes/addons/less/pages/home.less
@@ -1,3 +1,8 @@
 #home-search {
   margin-top: 16px;
 }
+
+#popularsort {
+  float: right;
+  margin-top: 5px;
+}

--- a/themes/addons/templates/Includes/AddonDownloadStats.ss
+++ b/themes/addons/templates/Includes/AddonDownloadStats.ss
@@ -1,7 +1,10 @@
 <span
 	data-toggle="tooltip" 
 	data-html="true"
-	title="Composer installations: &lt;br&gt;Total: $Downloads, Monthly: $DownloadsMonthly, Favers: $Favers &lt;br&gt;Source: packagist.org"
+	title="Composer installations: <br/>Total: $Downloads<br />
+	Monthly: $DownloadsMonthly<br />
+	Average downloads per day: $relativePopularityFormatted<br />
+	Favers: $Favers <br/>Source: packagist.org"
 >
-	<i class="icon-download"></i> $Downloads
+	<i class="icon-download"></i> <% if $Score %>$Score<% else %>$Downloads<% end_if %>
 </span>

--- a/themes/addons/templates/Includes/PopularAddons.ss
+++ b/themes/addons/templates/Includes/PopularAddons.ss
@@ -1,0 +1,10 @@
+<% loop $PopularAddons(5) %>
+    <li>
+        <a href="$Link">
+            <span class="meta"><% include AddonDownloadStats %></span>
+            <span class="name">$Name</span>
+            <% include ModuleRatingVisual SmallCircle=true %>
+            <span class="description">$Description</span>
+        </a>
+    </li>
+<% end_loop %>

--- a/themes/addons/templates/Layout/Home.ss
+++ b/themes/addons/templates/Layout/Home.ss
@@ -1,104 +1,105 @@
 <div class="row">
-	<div class="span12">
-	Welcome to the <a href="http://silverstripe.org">SilverStripe</a> add-on repository, based on the <a href="http://getcomposer.org">Composer</a> packaging system for PHP.  Use this site to find modules and themes to add to your SilverStripe website.  For best results, we recommend <a href="http://docs.silverstripe.org/en/getting_started/composer">managing your project with Composer</a>.
-	</div>
+    <div class="span12">
+        Welcome to the <a href="http://silverstripe.org">SilverStripe</a> add-on repository, based on the <a
+            href="http://getcomposer.org">Composer</a> packaging system for PHP. Use this site to find modules and
+        themes to add to your SilverStripe website. For best results, we recommend <a
+            href="http://docs.silverstripe.org/en/getting_started/composer">managing your project with Composer</a>.
+    </div>
 </div>
 
 <form id="home-search" action="/add-ons" method="get">
-	<div class="addons-search-row">
-		<label for="addons-search">Search for</label>
-		<input id="addons-search" type="text" name="search" class="input-block-level">
+    <div class="addons-search-row">
+        <label for="addons-search">Search for</label>
+        <input id="addons-search" type="text" name="search" class="input-block-level">
 
-		<button type="submit" class="btn">
-			<i class="icon-search"></i> Search Add-ons
-		</button>
-	</div>
+        <button type="submit" class="btn">
+            <i class="icon-search"></i> Search Add-ons
+        </button>
+    </div>
 </form>
 
 <hr>
 
 <div class="row">
-	<div class="addons-box span6">
-		<h3><a href="/add-ons?sort=downloads">Popular Add-ons</a></h3>
-		<ol>
-			<% loop $PopularAddons(5) %>
-				<li>
-					<a href="$Link">
-						<span class="meta"><% include AddonDownloadStats %></span>
-						<span class="name">$Name</span>
-						<% include ModuleRatingVisual SmallCircle=true %>
-						<span class="description">$Description</span>
-					</a>
-				</li>
-			<% end_loop %>
-		</ol>
-	</div>
+    <div class="addons-box span6">
+        <h3><a href="/add-ons?sort=downloads" class="popular-addons-list">Popular Add-ons
+        </a>
+            <select id="popularsort" class="sort-popularity dropdown" name="popularity">
+                <option value="Relative" selected="selected">Average downloads per day</option>
+                <option value="Absolute">Total downloads</option>
+            </select>
+        </h3>
+        <ol id="popularAddons">
+            <% include PopularAddons %>
+        </ol>
+    </div>
 
-	<div class="addons-box span6">
-		<h3>
-			<a href="/add-ons?sort=newest">Newest Add-ons</a>
-			<a class="pull-right" href="/add-ons/rss"><img src="themes/addons/images/feed-icon-14x14.png" alt="RSS Feed" /></a>
-		</h3>
-		<ol>
-			<% loop $NewestAddons(5) %>
-				<li>
-					<a href="$Link">
-						<span class="meta">$Released.Date</span>
-						<span class="name">$Name</span>
-						<% include ModuleRatingVisual SmallCircle=true %>
-						<span class="description">$Description</span>
-					</a>
-				</li>
-			<% end_loop %>
-		</ol>
-	</div>
+    <div class="addons-box span6">
+        <h3>
+            <a href="/add-ons?sort=newest">Newest Add-ons</a>
+            <a class="pull-right" href="/add-ons/rss"><img src="themes/addons/images/feed-icon-14x14.png"
+                                                           alt="RSS Feed"/></a>
+        </h3>
+        <ol>
+            <% loop $NewestAddons(5) %>
+                <li>
+                    <a href="$Link">
+                        <span class="meta">$Released.Date</span>
+                        <span class="name">$Name</span>
+                        <% include ModuleRatingVisual SmallCircle=true %>
+                        <span class="description">$Description</span>
+                    </a>
+                </li>
+            <% end_loop %>
+        </ol>
+    </div>
 </div>
 
 <div class="row">
-	<div class="addons-box span6">
-		<h3>Newest Releases</h3>
-		<ol>
-			<% loop $NewestVersions(5) %>
-				<li>
-					<a href="$Addon.Link">
-						<span class="meta">$Released.Date</span>
-						<span class="name">$Name</span>
-						<% include ModuleRatingVisual SmallCircle=true %>
-						<span class="description">$Description</span>
-					</a>
-				</li>
-			<% end_loop %>
-		</ol>
-	</div>
+    <div class="addons-box span6">
+        <h3>Newest Releases</h3>
+        <ol>
+            <% loop $NewestVersions(5) %>
+                <li>
+                    <a href="$Addon.Link">
+                        <span class="meta">$Released.Date</span>
+                        <span class="name">$Name</span>
+                        <% include ModuleRatingVisual SmallCircle=true %>
+                        <span class="description">$Description</span>
+                    </a>
+                </li>
+            <% end_loop %>
+        </ol>
+    </div>
 
-	<div class="addons-box span6">
-		<h3>Random Add-ons</h3>
-		<ul>
-			<% loop $RandomAddons(5) %>
-				<li>
-					<a href="$Link">
-						<span class="name">$Name</span>
-						<% include ModuleRatingVisual SmallCircle=true %>
-						<span class="description">$Description</span>
-					</a>
-				</li>
-			<% end_loop %>
-		</ul>
-	</div>
+    <div class="addons-box span6">
+        <h3>Random Add-ons</h3>
+        <ul>
+            <% loop $RandomAddons(5) %>
+                <li>
+                    <a href="$Link">
+                        <span class="name">$Name</span>
+                        <% include ModuleRatingVisual SmallCircle=true %>
+                        <span class="description">$Description</span>
+                    </a>
+                </li>
+            <% end_loop %>
+        </ul>
+    </div>
 </div>
 
 <% cached List(Addon).Max(Created) %>
-<div class="row">
-	<div class="addons-box span12">
-		<h3>Statistics</h3>
-		<ul>
-			<li>
-				<% loop ChartData %>
-					<div class="chart-data" data-x="$XValue" data-y="$YValue"></div>
-				<% end_loop %>
-				<div  id="chart-canvas"></div>
-			</li>
-		</ul>
-	</div>
-</div>
+    <div class="row">
+        <div class="addons-box span12">
+            <h3>Statistics</h3>
+            <ul>
+                <li>
+                    <% loop ChartData %>
+                        <div class="chart-data" data-x="$XValue" data-y="$YValue"></div>
+                    <% end_loop %>
+                    <div id="chart-canvas"></div>
+                </li>
+            </ul>
+        </div>
+    </div>
 <% end_cached %>


### PR DESCRIPTION
By default, on page load, show the average downloads per day since it first showed up in Packagist.

The user has the option to switch to total amount of downloads, which will do an ajax call to retrieve the rendered HTML for the total amount.
Or switch back, of course.

Sorting is done on the full float number, on the frontend, the number is formatted to 2 behind the separator.

Reasoning for using ajax for changing the content is obvious to me. It would be way to obtrusive to fully reload the page.

Note, it is _not_ applied to the add-ons page, which still only sorts by total downloads. I've been looking at that, but it needs more work to get it to work properly.