### PR TITLE
FIX OAuth rate limiting and non-GitHub readme parsing

### DIFF
--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -153,7 +153,7 @@ class AddonBuilder {
     public function replaceRelativeLinks(Addon $addon, $readme)
     {
         if (!$this->hasGitHubRepository($addon)) {
-            return $this;
+            return $readme;
         }
 
         $dom = new DOMDocument;

--- a/mysite/code/services/GitHubMarkdownService.php
+++ b/mysite/code/services/GitHubMarkdownService.php
@@ -121,6 +121,9 @@ class GitHubMarkdownService extends Object
         if (!$this->getContext()) {
             $endpoint .= '/raw';
         }
+        if (defined('SS_GITHUB_CLIENT_ID') && defined('SS_GITHUB_CLIENT_SECRET')) {
+            $endpoint .= sprintf('?client_id=%s&client_secret=%s', SS_GITHUB_CLIENT_ID, SS_GITHUB_CLIENT_SECRET);
+        }
         return $endpoint;
     }
 

--- a/mysite/code/services/GitHubMarkdownService.php
+++ b/mysite/code/services/GitHubMarkdownService.php
@@ -52,8 +52,6 @@ class GitHubMarkdownService extends Object
                     $this->getPayload($markdown)
                 );
             $body = (string) $request->send();
-
-            echo PHP_EOL, PHP_EOL, $body, PHP_EOL, PHP_EOL;
         } catch (RequestException $ex) {
             user_error($ex->getMessage());
             return '';

--- a/mysite/tests/services/AddonBuilderTest.php
+++ b/mysite/tests/services/AddonBuilderTest.php
@@ -142,4 +142,16 @@ HTML;
 
         $this->assertSame($expected, $this->builder->replaceRelativeLinks($addon, $input));
     }
+
+    /**
+     * For non GitHub repositories, the readme input should simply be returned as is from the "replaceRelativeLinks"
+     * method
+     */
+    public function testDoNotRewriteRelativeLinksForNonGitHubRepositories()
+    {
+        $addon = Addon::create();
+        $addon->Repository = 'https://gitlab.com/not-a/github-repo.git';
+        $readme = '<p>Please do not touch me.</p>';
+        $this->assertSame($readme, $this->builder->replaceRelativeLinks($addon, $readme));
+    }
 }


### PR DESCRIPTION
* FIX Handle OAuth client credentials from GitHub to prevent rate limit errors
* FIX Return original readme for non-GitHub repositories, remove debug line