### PR TITLE
FIX Tag search key should be "tags"

### DIFF
--- a/mysite/code/controllers/AddonsController.php
+++ b/mysite/code/controllers/AddonsController.php
@@ -130,7 +130,7 @@ class AddonsController extends SiteController
             }
 
             if ($tags) {
-                $bool->addMust(new Query\Terms('tag', (array)$tags));
+                $bool->addMust(new Query\Terms('tags', (array)$tags));
             }
 
             $list = new ResultList($this->elastica->getIndex(), $query);


### PR DESCRIPTION
This re-enables tag searching (#135). As noted in that issue, this will still not work for tags with dashes, e.g. "e-commerce", but will work for simple tags like "cwp" or "html5".