### PR TITLE
FIX Do not specify protocol for Gravatar URL to allow HTTPS

### DIFF
--- a/mysite/code/dataobjects/AddonAuthor.php
+++ b/mysite/code/dataobjects/AddonAuthor.php
@@ -21,7 +21,7 @@ class AddonAuthor extends DataObject
     public function GravatarUrl($size, $default = 'mm')
     {
         return sprintf(
-            'http://www.gravatar.com/avatar/%s?s=%d&d=%s',
+            'https://www.gravatar.com/avatar/%s?s=%d&d=%s',
             md5(strtolower(trim($this->Email))),
             $size,
             $default


### PR DESCRIPTION
One more "mixed content" warning I noticed on the addon detail page (UAT).

cc @sminnee