### PR TITLE
Remove GitHub contributors from authors list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ before_script:
       // EOF;
 script:
   - vendor/bin/phpunit mysite/tests
+  - vendor/bin/phpcs mysite
+

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
   "require-dev": {
     "phpunit/phpunit": "^4.8",
     "phpdocumentor/reflection-docblock": "~3.1.1",
-    "silverstripe/sqlite3": "*"
+    "silverstripe/sqlite3": "*",
+    "squizlabs/php_codesniffer": "^3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/mysite/code/controllers/AuthorsController.php
+++ b/mysite/code/controllers/AuthorsController.php
@@ -5,18 +5,18 @@
 class AuthorsController extends SiteController
 {
 
-    public static $url_handlers = array(
+    public static $url_handlers = [
         '$AuthorID!' => 'author'
-    );
+    ];
 
-    public static $allowed_actions = array(
+    public static $allowed_actions = [
         'index',
         'author'
-    );
+    ];
 
     public function index()
     {
-        return $this->renderWith(array('Authors', 'Page'));
+        return $this->renderWith(['Authors', 'Page']);
     }
 
     public function author($request)
@@ -43,6 +43,8 @@ class AuthorsController extends SiteController
 
     public function Authors()
     {
-        return AddonAuthor::get();
+        $authors = AddonAuthor::get();
+        $authors = $authors->exclude('Name', 'GitHub contributors');
+        return $authors;
     }
 }

--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -42,9 +42,9 @@ class AddonUpdater
     /**
      * Updates all add-ons.
      *
-     * @param Boolean Clear existing addons before updating them.
+     * @param boolean Clear existing addons before updating them.
      * Will also clear their search index, and cascade the delete for associated data.
-     * @param Array Limit to specific addons, using their name incl. vendor prefix.
+     * @param array Limit to specific addons, using their name incl. vendor prefix.
      */
     public function update($clear = false, $limitAddons = null)
     {

--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -294,12 +294,12 @@ class AddonUpdater
         //to-do api have no method to get this.
         /*$suggested = $package->getSuggests();
 
-		if ($suggested) foreach ($suggested as $package => $description) {
-			$link = $getLink($package, 'suggest');
-			$link->Description = $description;
+        if ($suggested) foreach ($suggested as $package => $description) {
+            $link = $getLink($package, 'suggest');
+            $link->Description = $description;
 
-			$version->Links()->add($link);
-		}*/
+            $version->Links()->add($link);
+        }*/
     }
 
     private function updateCompatibility(Addon $addon, AddonVersion $version, Version $package)

--- a/mysite/tests/Controllers/AuthorsControllerTest.php
+++ b/mysite/tests/Controllers/AuthorsControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
-class AuthorsControllerTest extends SapphireTest {
-
+class AuthorsControllerTest extends SapphireTest
+{
     protected static $fixture_file = 'AuthorsControllerTest.yml';
 
     public function testGithubContributorsAreExcludedInAuthorsIndex()
@@ -25,5 +25,4 @@ class AuthorsControllerTest extends SapphireTest {
         $this->assertNotContains('Github Contributors', $names);
         $this->assertNotContains('GitHub Contributors', $names);
     }
-
 }

--- a/mysite/tests/Controllers/AuthorsControllerTest.php
+++ b/mysite/tests/Controllers/AuthorsControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+class AuthorsControllerTest extends SapphireTest {
+
+    protected static $fixture_file = 'AuthorsControllerTest.yml';
+
+    public function testGithubContributorsAreExcludedInAuthorsIndex()
+    {
+        $controller = new AuthorsController();
+
+        $this->assertDOSContains(
+            [
+                ['Name' => 'Anna Green'],
+                ['Name' => 'Stephen McKenna'],
+                ['Name' => 'Kyra South'],
+                ['Name' => 'Frank Smith'],
+            ],
+            $controller->Authors()
+        );
+
+        $names = $controller->Authors()->map('ID', 'Name')->toArray();
+
+        $this->assertNotContains('GitHub contributors', $names);
+        $this->assertNotContains('Github contributors', $names);
+        $this->assertNotContains('Github Contributors', $names);
+        $this->assertNotContains('GitHub Contributors', $names);
+    }
+
+}

--- a/mysite/tests/Controllers/AuthorsControllerTest.yml
+++ b/mysite/tests/Controllers/AuthorsControllerTest.yml
@@ -1,0 +1,17 @@
+AddonAuthor:
+  author_a:
+    Name: Anna Green
+  author_b:
+    Name: Stephen McKenna
+  author_c:
+    Name: GitHub contributors
+  author_d:
+    Name: Github contributors
+  author_e:
+    Name: Kyra South
+  author_f:
+    Name: Frank Smith
+  author_g:
+    Name: Github Contributors
+  author_h:
+    Name: GitHub Contributors

--- a/mysite/tests/services/AddonBuilderTest.php
+++ b/mysite/tests/services/AddonBuilderTest.php
@@ -123,7 +123,7 @@ class AddonBuilderTest extends SapphireTest
     {
         $addon = Addon::create();
         $addon->Repository = 'https://github.com/silverstripe/silverstripe-framework';
-
+// phpcs:disable
         $input = <<<HTML
 <h1>Heading</h1>
 
@@ -139,6 +139,7 @@ HTML;
 
 <p><img src="https://github.com/silverstripe/silverstripe-framework/raw/master/relative.png"><img src="https://www.whatever.com/image.png"></p>
 HTML;
+// phpcs:enable
 
         $this->assertSame($expected, $this->builder->replaceRelativeLinks($addon, $input));
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="Addons">
+    <description>Coding standard for SilverStripe</description>
+
+    <!-- Use PSR-2 as a base standard -->
+    <rule ref="PSR2">
+        <!-- Allow classes to not declare a namespace -->
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+
+        <!-- Allow underscores in class names -->
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+
+        <!-- Allow non camel cased method names -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
We want meaningful results on the Authors tab. With this solution we only remove the `"GitHub contributors"` for the authors list, but retain it in all other contexts, such as the module level. 

Resolves #144 