### PR TITLE
NEW Adding capturing version information sent in headers as a metric

### DIFF
--- a/mysite/code/controllers/ApiController.php
+++ b/mysite/code/controllers/ApiController.php
@@ -1,4 +1,8 @@
 <?php
+
+/**
+ * Abstract controller for actions that provide an API endpoint.
+ */
 abstract class ApiController extends Controller
 {
     /**
@@ -22,5 +26,24 @@ abstract class ApiController extends Controller
         }
 
         return $response;
+    }
+
+    /**
+     * Overrides this method only to prepend capturing any provided framework version header
+     *
+     * @inheritDoc
+     */
+    protected function handleAction($request, $action)
+    {
+        $frameworkVersionHeader = $request->getHeader('Silverstripe-Framework-Version');
+
+        if ($frameworkVersionHeader) {
+            ApiCallerVersions::create([
+                'Endpoint' => $request->getURL(),
+                'Version' => $frameworkVersionHeader,
+            ])->write();
+        }
+
+        return parent::handleAction($request, $action);
     }
 }

--- a/mysite/code/dataobjects/ApiCallerVersions.php
+++ b/mysite/code/dataobjects/ApiCallerVersions.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Tracks any SilverStripe framework versions that are communicated in the headers of API calls (those handled by
+ * controllers that extend ApiController) made to addons.silverstripe.org
+ */
+class ApiCallerVersions extends DataObject
+{
+    private static $db = [
+        'Endpoint' => 'Varchar(255)',
+        'Version' => 'Varchar(100)',
+    ];
+
+    private static $indexes = [
+        'Version' => true,
+    ];
+}

--- a/mysite/tests/Controllers/ApiControllerTest.php
+++ b/mysite/tests/Controllers/ApiControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @mixin PHPUnit_Framework_TestCase
+ */
+class ApiControllerTest extends FunctionalTest
+{
+    protected $usesDatabase = true;
+
+    public function testFrameworkVersionSentInHeadersIsCollected()
+    {
+        $this->get('api/supported-addons', null, [
+            'Silverstripe-Framework-Version' => '1.2.3',
+        ]);
+
+        $metrics = ApiCallerVersions::get();
+
+        $this->assertCount(1, $metrics);
+        $this->assertSame('1.2.3', $metrics->first()->Version);
+    }
+}


### PR DESCRIPTION
As titled. Adds a catch all in the abstract `ApiController` and logs any action dispatch as long as the header `Silverstripe-Framework-Version` is set.