### PR TITLE
NEW Add ratings API controller that supports bulk rating data in a request

### DIFF
--- a/mysite/_config/routes.yml
+++ b/mysite/_config/routes.yml
@@ -11,4 +11,5 @@ Director:
     "submit": SubmitAddonController
     "addonSort": AjaxController
     'api/rating': RatingApiController
+    'api/ratings': RatingsApiController
     'api/supported-addons': SupportedAddonsApiController

--- a/mysite/code/controllers/ApiController.php
+++ b/mysite/code/controllers/ApiController.php
@@ -6,6 +6,14 @@
 abstract class ApiController extends Controller
 {
     /**
+     * Set the default cache lifetime in seconds. Only used outside of "dev" environments.
+     *
+     * @config
+     * @var int
+     */
+    private static $cache_age = 10800;
+
+    /**
      * Given a result payload, format as a JSON response and return
      *
      * @param array $data

--- a/mysite/code/controllers/RatingsApiController.php
+++ b/mysite/code/controllers/RatingsApiController.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * The ratings API controller provides access to bulk ratings information for a list of addons provided
+ * via the `addons` query string argument, comma delimited.
+ *
+ * For individual (including detailed) rating metrics, use the RatingApiController
+ */
+class RatingsApiController extends ApiController
+{
+    private static $allowed_actions = [
+        'index',
+    ];
+
+    public function index(SS_HTTPRequest $request)
+    {
+        if (!$request->getVar('addons')) {
+            return $this->formatResponse([
+                'success' => false,
+                'message' => 'Missing or incomplete module names',
+            ]);
+        }
+
+        $addonNames = $request->getVar('addons');
+        /** @var Addon[] $addons */
+        $addons = Addon::get()
+            ->filter(['Name' => explode(',', $request->getVar('addons'))])
+            ->map('Name', 'Rating');
+
+        return $this->formatResponse([
+            'success' => true,
+            'ratings' => $addons->toArray()
+        ]);
+    }
+}

--- a/mysite/tests/Controllers/RatingApiControllerTest.yml
+++ b/mysite/tests/Controllers/RatingApiControllerTest.yml
@@ -3,3 +3,6 @@ Addon:
     Name: foo/bar
     Rating: 53
     RatingDetails: '{"coverage":3,"tests":5}'
+  addon_b:
+    Name: far/baz
+    Rating: 83

--- a/mysite/tests/Controllers/RatingsApiControllerTest.php
+++ b/mysite/tests/Controllers/RatingsApiControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @mixin PHPUnit_Framework_TestCase
+ */
+class RatingsApiControllerTest extends FunctionalTest
+{
+    protected static $fixture_file = 'RatingApiControllerTest.yml';
+
+    public function testGetRatingsForMultipleModules()
+    {
+        $response = $this->get('api/ratings?addons=foo/bar,far/baz');
+
+        $this->assertJson($response->getBody());
+
+        $result = json_decode($response->getBody());
+        $this->assertTrue($result->success);
+        $this->assertNotEmpty($result->ratings);
+        $this->assertEquals(53, $result->ratings->{'foo/bar'});
+        $this->assertEquals(83, $result->ratings->{'far/baz'});
+    }
+
+    public function testMissingAddonsAreOmittedFromResults()
+    {
+        $response = $this->get('api/ratings?addons=silverstripe/imaginarymodule');
+
+        $this->assertJson($response->getBody());
+
+        $result = json_decode($response->getBody());
+        $this->assertTrue($result->success);
+        $this->assertEmpty($result->ratings);
+    }
+}


### PR DESCRIPTION
Also moves the default cache age value for RatingsController and RatingController into the base ApiController

This will allow consumers (such as the silverstripe-maintenance module) to get all rating data in one request rather than performing lots of subsequent requests.