### PR TITLE
FIX Rather than omitting abandoned modules, they are displayed with a warning.

### DIFF
--- a/mysite/code/dataobjects/Addon.php
+++ b/mysite/code/dataobjects/Addon.php
@@ -22,6 +22,7 @@ class Addon extends DataObject
         'LastUpdated'       => 'SS_Datetime',
         'LastBuilt'         => 'SS_Datetime',
         'BuildQueued'       => 'Boolean',
+        'Abandoned'         => 'Boolean',
         // Module rating information
         'Rating'            => 'Int',
         'RatingDetails'     => 'Text',

--- a/mysite/code/dataobjects/Addon.php
+++ b/mysite/code/dataobjects/Addon.php
@@ -22,7 +22,7 @@ class Addon extends DataObject
         'LastUpdated'       => 'SS_Datetime',
         'LastBuilt'         => 'SS_Datetime',
         'BuildQueued'       => 'Boolean',
-        'Abandoned'         => 'Boolean',
+        'Abandoned'         => 'Text',
         // Module rating information
         'Rating'            => 'Int',
         'RatingDetails'     => 'Text',

--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -1,12 +1,10 @@
 <?php
 
-use Composer\Package\AliasPackage;
-use Composer\Package\CompletePackage;
-use Guzzle\Http\Exception\ClientErrorResponseException;
-use SilverStripe\Elastica\ElasticaService;
-use Packagist\Api\Result\Package;
 use Composer\Package\Version\VersionParser;
+use Guzzle\Http\Exception\ClientErrorResponseException;
+use Packagist\Api\Result\Package;
 use Packagist\Api\Result\Package\Version;
+use SilverStripe\Elastica\ElasticaService;
 
 /**
  * Updates all add-ons from Packagist.
@@ -88,20 +86,11 @@ class AddonUpdater
             $addon = Addon::get()->filter('Name', $name)->first();
 
             if (!$addon) {
-                if ($isAbandoned) {
-                    echo ' - Skipping abandoned package: ' . $name, PHP_EOL;
-                    continue;
-                }
 
                 $addon = new Addon();
                 $addon->Name = $name;
+                $addon->Abandoned = $isAbandoned;
                 $addon->write();
-            }
-
-            if ($isAbandoned) {
-                echo ' - Removing abandoned package: ' . $name, PHP_EOL;
-                $addon->delete();
-                continue;
             }
 
             usort($versions, function ($a, $b) {

--- a/mysite/code/services/AddonUpdater.php
+++ b/mysite/code/services/AddonUpdater.php
@@ -86,10 +86,8 @@ class AddonUpdater
             $addon = Addon::get()->filter('Name', $name)->first();
 
             if (!$addon) {
-
                 $addon = new Addon();
                 $addon->Name = $name;
-                $addon->Abandoned = $isAbandoned;
                 $addon->write();
             }
 
@@ -135,6 +133,7 @@ class AddonUpdater
         }
 
         $addon->Type = preg_replace('/^silverstripe-(vendor)?/', '', $package->getType());
+        $addon->Abandoned = $package->getAbandoned();
         $addon->Description = $package->getDescription();
         $addon->Released = strtotime($package->getTime());
         $addon->Repository = $package->getRepository();

--- a/mysite/code/services/PackagistService.php
+++ b/mysite/code/services/PackagistService.php
@@ -3,7 +3,6 @@
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Package\Loader\ArrayLoader;
-use Composer\Repository\ComposerRepository;
 
 /**
  * Interacts with Packagist to retrieve package listings and details.

--- a/themes/addons/templates/Layout/Addon.ss
+++ b/themes/addons/templates/Layout/Addon.ss
@@ -41,7 +41,7 @@
 
     <% if $Abandoned %>
         <p class="alert alert-warning">
-            This package is abandoned and no longer maintained.
+            This package is abandoned and no longer maintained. It is suggested to use <a href="https://addons.silverstripe.org/add-ons/$Abandoned.ATT">$Abandoned.XML</a> instead.
         </p>
     <% end_if %>
 

--- a/themes/addons/templates/Layout/Addon.ss
+++ b/themes/addons/templates/Layout/Addon.ss
@@ -39,6 +39,12 @@
 		</ul>
 	<% end_if %>
 
+    <% if $Abandoned %>
+        <p class="alert alert-warning">
+            This package is abandoned and no longer maintained.
+        </p>
+    <% end_if %>
+
 	<dl id="metadata">
 		<% with $MasterVersion %>
 			<dt>Homepage:</dt>


### PR DESCRIPTION
Fixes #159. 



This change displays abandoned modules again on Addons. In the detailed Addon view, a warning message is displayed prominently to alert users to the fact that the module is no longer maintained. 

The next step is to show alternative modules which are recommended instead.

![image](https://user-images.githubusercontent.com/14869519/41445497-15f619a0-709e-11e8-8f47-8080e263a2d8.png)

^ _The top message can be ignored, as I haven't build the modules for my test site._ 