### PR TITLE
Revert "Adding downloads into the score calculation for ranking results"

### DIFF
--- a/mysite/code/controllers/AddonsController.php
+++ b/mysite/code/controllers/AddonsController.php
@@ -33,11 +33,6 @@ class AddonsController extends SiteController
      */
     private $elastica;
 
-    /**
-     * @var PaginatedList|Addon[]
-     */
-    protected $addons;
-
     public function index()
     {
         return $this->renderWith(array('Addons', 'Page'));
@@ -101,10 +96,6 @@ class AddonsController extends SiteController
     {
         $list = Addon::get();
 
-        if ($this->addons !== null) {
-            return $this->addons;
-        }
-
         $search = $this->request->getVar('search');
         $type = $this->request->getVar('type');
         $compat = $this->request->getVar('compatibility');
@@ -134,22 +125,8 @@ class AddonsController extends SiteController
                     'readme',
                 ]);
                 $match->setType('phrase_prefix');
-                $match->setUseDisMax(false);
 
-                $query->setSort([
-                    '_score',
-                    'downloads',
-                ]);
-
-                $scorer = new Query\FunctionScore();
-                $scorer->setQuery($match);
-                $scorer->addFieldValueFactorFunction(
-                    'downloads',
-                    0.01,
-                    Query\FunctionScore::FIELD_VALUE_FACTOR_MODIFIER_LN2P
-                );
-
-                $bool->addMust($scorer);
+                $bool->addMust($match);
                 $useElasticOrderAsDefault = true;
             }
 
@@ -212,7 +189,7 @@ class AddonsController extends SiteController
                 }
         }
 
-        $list = $this->addons = new PaginatedList($list, $this->request);
+        $list = new PaginatedList($list, $this->request);
         $list->setPageLength(16);
 
         return $list;


### PR DESCRIPTION
Reverts silverstripe/addons.silverstripe.org#201

This PR doesn't work on UAT - apparently the ElasticSearch schema is different and SSP helpdesk informed me it wasn't easy to get any details. Might have to do a little more debugging on this one in the future.