### PR TITLE
Add a monolog syslogger to enable module rating check suites to report failures to Graylog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "squizlabs/php_codesniffer": "^3",
     "symbiote/silverstripe-gridfieldextensions": "^2",
     "silverstripe/raygun": "^1",
-    "sminnee/stitchdata-php": "^0.1"
+    "sminnee/stitchdata-php": "^0.1",
+    "monolog/monolog": "^1.23"
   },
   "replace": {
     "extensions.silverstripe.org": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6eb4b47789802df86061269ef17cdb3b",
+    "content-hash": "c02395154e43a8064b2054a8fd077fe9",
     "packages": [
         {
             "name": "asyncphp/doorman",
@@ -1106,6 +1106,84 @@
             "time": "2018-02-25T21:50:11+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
             "name": "mtdowling/cron-expression",
             "version": "v1.2.1",
             "source": {
@@ -1900,20 +1978,21 @@
         },
         {
             "name": "silverstripe/moduleratings",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/moduleratings.git",
-                "reference": "7847da4536045c0c62db85ed82bd3815c6525357"
+                "reference": "6c1f6c5d040efae43b090c8ee324eb7fe22d84a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/moduleratings/zipball/7847da4536045c0c62db85ed82bd3815c6525357",
-                "reference": "7847da4536045c0c62db85ed82bd3815c6525357",
+                "url": "https://api.github.com/repos/silverstripe/moduleratings/zipball/6c1f6c5d040efae43b090c8ee324eb7fe22d84a0",
+                "reference": "6c1f6c5d040efae43b090c8ee324eb7fe22d84a0",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^6",
+                "psr/log": "^1.0",
                 "symfony/console": "~3.0|~4.0",
                 "symfony/finder": "~3.0|~4.0",
                 "symfony/yaml": "~3.0|~4.0"
@@ -1945,7 +2024,7 @@
                 }
             ],
             "description": "A library to provide module code quality ratings",
-            "time": "2018-05-10T21:49:11+00:00"
+            "time": "2018-09-14T14:18:33+00:00"
         },
         {
             "name": "silverstripe/moduleratings-plugin",

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -2,6 +2,7 @@
 
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\SyslogHandler;
 use SilverStripe\ModuleRatings\CheckSuite;
 
@@ -37,6 +38,8 @@ class AddonBuilder
         $logger = new Monolog\Logger('module_ratings_logs', [
             new SyslogHandler('SilverStripe_log'),
         ]);
+        $formatter = new LineFormatter("%level_name%: %message% %context% %extra%");
+        $logger->setFormatter($formatter);
         $checkSuite->setLogger($logger);
 
         $composer = $this->packagist->getComposer();

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -2,6 +2,7 @@
 
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
+use Monolog\Handler\SyslogHandler;
 use SilverStripe\ModuleRatings\CheckSuite;
 
 /**
@@ -29,7 +30,14 @@ class AddonBuilder
     public function build(Addon $addon)
     {
         putenv("GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no\"");
-        $this->setCheckSuite(new CheckSuite());
+
+        $checkSuite = new CheckSuite();
+        $this->setCheckSuite($checkSuite);
+        // Provide the checksuite with a logger in case API calls fail
+        $logger = new Monolog\Logger('module_ratings_logs', [
+            new SyslogHandler('SilverStripe_log'),
+        ]);
+        $checkSuite->setLogger($logger);
 
         $composer = $this->packagist->getComposer();
         $downloader = $composer->getDownloadManager();


### PR DESCRIPTION
Also brings through the change that include a Travis CI API token if one exists in the environment (in the module ratings library)