### PR TITLE
FIX travis_passing was renamed to ci_passing, and fatal error calling setFormatter on wrong class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "c02395154e43a8064b2054a8fd077fe9",
@@ -1599,6 +1599,7 @@
                 "array_column",
                 "column"
             ],
+            "abandoned": true,
             "time": "2015-03-20T22:07:39+00:00"
         },
         {
@@ -1978,16 +1979,16 @@
         },
         {
             "name": "silverstripe/moduleratings",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/moduleratings.git",
-                "reference": "6c1f6c5d040efae43b090c8ee324eb7fe22d84a0"
+                "reference": "a6c31fd4d3e5c1bccccf59c1a53c51502a498737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/moduleratings/zipball/6c1f6c5d040efae43b090c8ee324eb7fe22d84a0",
-                "reference": "6c1f6c5d040efae43b090c8ee324eb7fe22d84a0",
+                "url": "https://api.github.com/repos/silverstripe/moduleratings/zipball/a6c31fd4d3e5c1bccccf59c1a53c51502a498737",
+                "reference": "a6c31fd4d3e5c1bccccf59c1a53c51502a498737",
                 "shasum": ""
             },
             "require": {
@@ -2024,7 +2025,7 @@
                 }
             ],
             "description": "A library to provide module code quality ratings",
-            "time": "2018-09-14T14:18:33+00:00"
+            "time": "2019-02-01T11:56:21+00:00"
         },
         {
             "name": "silverstripe/moduleratings-plugin",

--- a/mysite/code/dataobjects/Addon.php
+++ b/mysite/code/dataobjects/Addon.php
@@ -207,7 +207,7 @@ class Addon extends DataObject
             ['Metric' => $metrics->good_code_coverage, 'Description' => 'Good code coverage (>40%)'],
             ['Metric' => $metrics->great_code_coverage, 'Description' => 'Great code coverage (>75%)'],
             ['Metric' => $metrics->has_documentation, 'Description' => 'Documentation'],
-            ['Metric' => $metrics->travis_passing, 'Description' => 'Travis passing'],
+            ['Metric' => $metrics->ci_passing, 'Description' => 'CI builds passing'],
             ['Metric' => $metrics->good_scrutinizer_score, 'Description' => 'Scrutinizer >6.5'],
             ['Metric' => $metrics->coding_standards, 'Description' => 'PSR-2 standards'],
         ]);

--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -35,11 +35,11 @@ class AddonBuilder
         $checkSuite = new CheckSuite();
         $this->setCheckSuite($checkSuite);
         // Provide the checksuite with a logger in case API calls fail
-        $logger = new Monolog\Logger('module_ratings_logs', [
-            new SyslogHandler('SilverStripe_log'),
+        $logger = new \Monolog\Logger('module_ratings_logs', [
+            $handler = new SyslogHandler('SilverStripe_log'),
         ]);
         $formatter = new LineFormatter("%level_name%: %message% %context% %extra%");
-        $logger->setFormatter($formatter);
+        $handler->setFormatter($formatter);
         $checkSuite->setLogger($logger);
 
         $composer = $this->packagist->getComposer();


### PR DESCRIPTION
There were two bugs I found:

* `setFormatter()` was being called on Monolog, it should be called on the handler. This was causing a fatal error and preventing any rating build jobs from running (soz)
* `travis_passing` was renamed to `ci_passing` in the check suite, forgot to update the addons end
* There were some undefined index notices in the module ratings package which I've updated and pulled into the project (non-blocking, but filling up logs with noise)

Fixes #210