### PR TITLE
Handle missing Packagist versions gracefully

### DIFF
--- a/mysite/code/services/AddonBuilder.php
+++ b/mysite/code/services/AddonBuilder.php
@@ -42,13 +42,13 @@ class AddonBuilder
         $handler->setFormatter($formatter);
         $checkSuite->setLogger($logger);
 
-        $composer = $this->packagist->getComposer();
-        $downloader = $composer->getDownloadManager();
         $packageVersions = $this->packagist->getPackageVersions($addon->Name);
         $time = time();
 
         if (!$packageVersions) {
-            throw new Exception('Could not find corresponding Packagist versions');
+            echo "No versions found on Packagist for " . $addon->Name . "; deleting orphan record.\n";
+            $addon->delete();
+            return;
         }
 
         // Get the latest local and packagist version pair.


### PR DESCRIPTION
The Addons Builder is currently broken, due to [a rogue package on Packagist](https://packagist.org/packages/mparkhill/silverstripe-tcpdf) which has no versions listed (due to the related GitHub repository being deleted).

Since this appears to be a real and valid state for a Packagist entry to be in, this PR adjusts the related logic to simply remove the Addon from the database rather than throwing an Exception.