### PR TITLE
FIX UpdateAddonsTask now filters Packagist API calls, and broken replacement for abandoned packages message commented out

### DIFF
--- a/app/src/services/AddonUpdater.php
+++ b/app/src/services/AddonUpdater.php
@@ -64,12 +64,13 @@ class AddonUpdater
         }
 
         // This call to packagist can be expensive. Requests are served from a cache if usePackagistCache() returns true
+        /** @var CacheInterface $cache */
         $cache = Injector::inst()->get(CacheInterface::class . '.addons');
 
         if ($this->usePackagistCache() && $packages = $cache->get('AddonUpdater-packagist')) {
             $packages = unserialize($packages);
         } else {
-            $packages = $this->packagist->getPackages();
+            $packages = $this->packagist->getPackages($limitAddons);
             $cache->set('AddonUpdater-packagist', serialize($packages));
         }
 
@@ -82,8 +83,6 @@ class AddonUpdater
 
         foreach ($packages as $package) {
             /** @var Packagist\Api\Result\Package $package */
-
-            $isAbandoned = (method_exists($package, 'isAbandoned') && $package->isAbandoned());
             $name = $package->getName();
             $versions = $package->getVersions();
 

--- a/app/src/services/PackagistService.php
+++ b/app/src/services/PackagistService.php
@@ -38,20 +38,21 @@ class PackagistService
     /**
      * Gets all SilverStripe packages.
      *
-     * @return Packagist\Api\Package[]
+     * @param string[] $limitAddons If specified, can be a list of addons to restrict the return to
+     * @return Packagist\Api\Result\Package[]
      */
-    public function getPackages()
+    public function getPackages(array $limitAddons = [])
     {
-        $packages = array();
-        $loader = new ArrayLoader();
+        $packages = [];
 
-        $addonTypes = array(
+        // Look up by package type
+        $addonTypes = [
             'silverstripe-module',
             'silverstripe-vendormodule',
             'silverstripe-theme'
-        );
+        ];
         foreach ($addonTypes as $type) {
-            $repositoriesNames = $this->client->all(array('type' => $type));
+            $repositoriesNames = $limitAddons ?: $this->client->all(['type' => $type]);
             foreach ($repositoriesNames as $name) {
                 $packages[] = $this->client->get($name);
                 echo $name . PHP_EOL; //output to give feedback when running

--- a/app/src/tasks/BuildAddonsTask.php
+++ b/app/src/tasks/BuildAddonsTask.php
@@ -1,5 +1,6 @@
 <?php
 
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
 
 /**
@@ -37,7 +38,7 @@ class BuildAddonsTask extends BuildTask
 
     /**
      * {@inheritDoc}
-     * @param SS_HTTPRequest $request
+     * @param HTTPRequest $request
      */
     public function run($request)
     {

--- a/app/src/tasks/UpdateAddonsTask.php
+++ b/app/src/tasks/UpdateAddonsTask.php
@@ -1,5 +1,6 @@
 <?php
 
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
 
 /**
@@ -36,13 +37,14 @@ class UpdateAddonsTask extends BuildTask
 
     /**
      * {@inheritDoc}
-     * @param SS_HTTPRequest $request
+     * @param HTTPRequest $request
      */
     public function run($request)
     {
+        $addons = $request->getVar('addons');
         $this->updater->update(
             (bool)$request->getVar('clear'),
-            $request->getVar('addons') ? explode(',', $request->getVar('addons')) : null
+            $addons ? explode(',', $addons) : null
         );
     }
 }

--- a/themes/addons/templates/Layout/Addon.ss
+++ b/themes/addons/templates/Layout/Addon.ss
@@ -41,7 +41,7 @@
 
     <% if $Abandoned %>
         <p class="alert alert-warning">
-            This package is abandoned and no longer maintained. It is suggested to use <a href="https://addons.silverstripe.org/add-ons/$Abandoned.ATT">$Abandoned.XML</a> instead.
+            This package is abandoned and no longer maintained. <%-- It is suggested to use <a href="https://addons.silverstripe.org/add-ons/$Abandoned.ATT">$Abandoned.XML</a> instead.--%>
         </p>
     <% end_if %>
 


### PR DESCRIPTION
Resolves https://github.com/silverstripe/addons.silverstripe.org/issues/230

See justification on that issue for commenting out the text rather than removing it (it may come back again at some point)