### PR TITLE
FIX Add overloaded ElasticaService to delete existing indexes before defining them

### DIFF
--- a/app/_config.php
+++ b/app/_config.php
@@ -43,6 +43,6 @@ if (Environment::getEnv('ELASTICSEARCH_HOST') && Environment::getEnv('ELASTICSEA
         $esIndex = 'addons';
     }
 
-    $esService = new ElasticaService($esClient, $esIndex, Injector::inst()->get(LoggerInterface::class));
+    $esService = new SSElasticaService($esClient, $esIndex, Injector::inst()->get(LoggerInterface::class));
     Injector::inst()->registerService($esService, ElasticaService::class);
 }

--- a/app/src/services/SSElasticaService.php
+++ b/app/src/services/SSElasticaService.php
@@ -1,0 +1,24 @@
+<?php
+
+
+use Heyday\Elastica\ElasticaService;
+
+/**
+ * Temporary class workaround for https://github.com/heyday/silverstripe-elastica/issues/19
+ */
+class SSElasticaService extends ElasticaService
+{
+    /**
+     * Clears an existing index before allowing it to be recreated again
+     *
+     * See https://github.com/silverstripe/addons.silverstripe.org/issues/241
+     */
+    public function define()
+    {
+        $index = $this->getIndex();
+        if ($index->exists()) {
+            $index->delete();
+        }
+        parent::define();
+    }
+}


### PR DESCRIPTION
This allows us to change mapping types without having it throw fatal errors on reindexing. This commit can be reverted and have heyday/silverstripe-elastica updated once the upstream PR is merged and tagged.

Hopefully will help for https://github.com/silverstripe/addons.silverstripe.org/issues/241, but needs to be tested on UAT and prod before we can actually close the issue.

The reason why the index mappings are persisting across manual CLI calls to delete the index are a mystery to me, but running this procedurally in the same process should avoid the issue anyway.